### PR TITLE
fix: Add --allow-same-version to npm version step

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -57,7 +57,7 @@ jobs:
         if: github.event.inputs.version
         working-directory: js-bindings
         run: |
-          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version --allow-same-version
       
       - name: Publish to npm
         working-directory: js-bindings


### PR DESCRIPTION
Prevents CI failure when package.json already has the target version.