### PR TITLE
docs: Rewrite README with compelling sales hook + bump Zig to 0.15.2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.15.1
+          version: 0.15.2
       
       - name: Build Zig library
         run: |


### PR DESCRIPTION
## Summary
- Rewrites README with speed-first narrative: "136x faster than Pydantic. 78x faster than Zod. Same API."
- Shows drop-in replacement examples for Python (Pydantic), TypeScript (Zod), and Zig (comptime)
- Includes benchmark tables, architecture diagram, and install instructions
- Bumps CI Zig version from 0.15.1 → 0.15.2 for forward compatibility

## Test plan
- [x] README renders correctly in GitHub markdown
- [x] CI workflow uses latest stable Zig (0.15.2)
- [x] No code changes — documentation and CI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)