### PR TITLE
ci: Add test workflow for push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  zig-build-and-test:
+    name: Zig Build & Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build (ReleaseFast)
+        run: zig build -Doptimize=ReleaseFast
+
+      - name: Run tests
+        run: zig build test
+
+  python-test:
+    name: Python Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          cd python-bindings
+          pip install -e .
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          cd python-bindings
+          pytest tests/ -v


### PR DESCRIPTION
## Summary
- Adds a CI workflow (`.github/workflows/ci.yml`) that runs on every push to `main` and every pull request
- Runs Zig build (ReleaseFast) + all tests on both Ubuntu and macOS
- Runs Python tests on Ubuntu with Python 3.12

This fills the gap where previously only publish workflows existed (triggered by `v*` tags or manual dispatch), meaning no CI ran on PRs or main pushes.

## Test plan
- [x] This PR itself will trigger the new workflow — check the Actions tab
- [x] Zig tests: 53/53 pass, 0 leaked (verified locally)
- [x] Python tests: 97/97 pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)