### PR TITLE
ci: Full wheel coverage — Python 3.9-3.14 + Linux aarch64 + free-threaded

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_zig_library:
-    name: Build Zig Library
+    name: Build Zig Library (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -16,77 +16,94 @@ jobs:
           - os: ubuntu-latest
             arch: x86_64
             target: x86_64-linux-gnu
+          - os: ubuntu-latest
+            arch: aarch64
+            target: aarch64-linux-gnu
           - os: macos-latest
             arch: arm64
             target: aarch64-macos-none
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.15.2
-      
+
       - name: Build Zig library
         run: |
           zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
-      
+
       - name: Upload Zig library artifact
         uses: actions/upload-artifact@v4
         with:
-          name: zig-lib-${{ matrix.os }}-${{ matrix.arch }}
+          name: zig-lib-${{ matrix.arch }}
           path: |
             zig-out/lib/libsatya.*
             zig-out/lib/satya.*
           retention-days: 1
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Wheels (${{ matrix.os }}-${{ matrix.arch }})
     needs: build_zig_library
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]  # Windows support coming soon
-    
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            zig-artifact: zig-lib-x86_64
+            cibw-archs: x86_64
+          - os: ubuntu-latest
+            arch: aarch64
+            zig-artifact: zig-lib-aarch64
+            cibw-archs: aarch64
+          - os: macos-latest
+            arch: arm64
+            zig-artifact: zig-lib-arm64
+            cibw-archs: arm64
+
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Download Zig library artifacts
+
+      - name: Set up QEMU
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Download Zig library
         uses: actions/download-artifact@v4
         with:
-          path: zig-artifacts
-      
-      - name: Copy Zig libraries to zig-out
-        shell: bash
+          name: ${{ matrix.zig-artifact }}
+          path: zig-out/lib
+
+      - name: Verify Zig library
         run: |
-          mkdir -p zig-out/lib
-          if [ -d "zig-artifacts" ]; then
-            find zig-artifacts -name "libsatya.*" -o -name "satya.*" | while read file; do
-              cp "$file" zig-out/lib/ || true
-            done
-          fi
-          ls -la zig-out/lib/ || true
-      
+          echo "Zig library for ${{ matrix.arch }}:"
+          ls -la zig-out/lib/
+          file zig-out/lib/libsatya.* || true
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-*
           CIBW_SKIP: "*-musllinux_* *-manylinux_i686 *-win32"
-          CIBW_ARCHS_MACOS: "arm64"
-          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS: ${{ matrix.cibw-archs }}
           CIBW_BEFORE_BUILD: |
             pip install setuptools wheel
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13.0
+          CIBW_FREE_THREADED_SUPPORT: 1
         with:
           package-dir: ./python-bindings
           output-dir: wheelhouse
-      
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
           retention-days: 7
 
@@ -95,13 +112,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Build sdist
         run: |
           cd python-bindings
           pip install build
           python -m build --sdist
-      
+
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
@@ -114,20 +131,21 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    
+
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist-all
-      
+
       - name: Flatten dist directory
         run: |
           mkdir -p dist
           find dist-all -name "*.whl" -exec cp {} dist/ \;
           find dist-all -name "*.tar.gz" -exec cp {} dist/ \;
+          echo "Wheels to publish:"
           ls -la dist/
-      
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.1.0"
+version = "1.1.1"
 description = "Ultra-fast data validation for Python - 28M validations/sec, 3x faster than Rust alternatives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Adds Linux aarch64 wheel builds (Zig cross-compiles from x86_64, cibuildwheel uses QEMU)
- Adds Python 3.13t (free-threaded) and Python 3.14 wheel builds
- Each wheel job now downloads only its architecture-matched Zig library (no more architecture mismatch)
- Bumps version to 1.1.1

## Wheel matrix (before → after)

| Platform | Before | After |
|----------|--------|-------|
| Linux x86_64 | cp39-cp313 | cp39-cp314 + cp313t |
| Linux aarch64 | ❌ | cp39-cp314 + cp313t |
| macOS arm64 | cp39-cp313 | cp39-cp314 + cp313t |

## Test plan
- [x] CI workflow validates Zig build + tests pass
- [ ] Build wheels workflow succeeds (will verify after merge + tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)