### PR TITLE
chore: Bump version to 1.1.16 for release

### DIFF
--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.1.15"
+version = "1.1.16"
 description = "Ultra-fast data validation for Python - 28M validations/sec, 3x faster than Rust alternatives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Bump version to 1.1.16 in js-bindings/package.json
- Bump version to 1.1.16 in python-bindings/pyproject.toml  
- Bump version to 1.1.16 in python-bindings/dhi/__init__.py

This release includes the CI test path fix from the previous commit.

## Test plan
- [ ] CI tests pass on this PR
- [ ] After merge, create v1.1.16 tag to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)