### PR TITLE
fix(ci): Correct import paths in benchmark files

### DIFF
--- a/js-bindings/benchmarks/benchmark-json.ts
+++ b/js-bindings/benchmarks/benchmark-json.ts
@@ -2,7 +2,7 @@
  * Benchmark: dhi vs Zod — JSON output for CI
  * Outputs results as JSON for chart generation
  */
-import { z as dhi } from './schema';
+import { z as dhi } from '../schema';
 import { z as zod } from 'zod';
 import { writeFileSync } from 'fs';
 

--- a/js-bindings/benchmarks/benchmark-zod4-features.ts
+++ b/js-bindings/benchmarks/benchmark-zod4-features.ts
@@ -1,7 +1,7 @@
 /**
  * Benchmark: dhi vs Zod 4 — New Zod 4 Features
  */
-import { z as dhi } from './schema';
+import { z as dhi } from '../schema';
 import { z as zod } from 'zod';
 
 function bench(fn: () => void, iterations: number = 1_000_000): number {


### PR DESCRIPTION
## Summary

Fix relative import paths from `'./schema'` to `'../schema'` in benchmark files since they are located in the `benchmarks/` subdirectory.

## Files Fixed

- `js-bindings/benchmarks/benchmark-json.ts`
- `js-bindings/benchmarks/benchmark-zod4-features.ts`

## Test plan

- [x] CI benchmark workflow should now pass