### PR TITLE
fix(ci): Add canvas dependency for chart generation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install canvas system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
       - name: Install dependencies
         working-directory: js-bindings
         run: bun install

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -93,6 +93,7 @@
     "@types/bun": "^1.2.5",
     "@types/node": "^20.19.30",
     "arktype": "^2.1.29",
+    "canvas": "^2.11.2",
     "typescript": "^5.9.3",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.1"


### PR DESCRIPTION
## Summary

Fix the benchmark CI workflow by adding the missing `canvas` package dependency.

## Changes

1. Added `canvas` to devDependencies in `js-bindings/package.json`
2. Added system dependencies installation step in `.github/workflows/benchmarks.yml`:
   - libcairo2-dev
   - libpango1.0-dev
   - libjpeg-dev
   - libgif-dev
   - librsvg2-dev

## Test plan

- [x] Workflow should now install canvas and its system dependencies
- [ ] Benchmark charts should be generated successfully