### PR TITLE
feat(js): Add Vercel AI SDK native compatibility

### DIFF
--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -267,11 +267,17 @@ export type SafeParseResult<T> =
 // Base Schema Type
 // ============================================================================
 
+// AI SDK compatibility symbol
+const schemaSymbol = Symbol.for("vercel.ai.schema");
+
 export abstract class DhiType<Output = any, Input = Output> {
   readonly _output!: Output;
   readonly _input!: Input;
   _description?: string;
   _metadata?: Record<string, any>;
+
+  // AI SDK compatibility marker - makes isSchema() return true
+  readonly [schemaSymbol] = true;
 
   abstract _parse(value: unknown, path: (string | number)[]): SafeParseResult<Output>;
 
@@ -417,6 +423,16 @@ export abstract class DhiType<Output = any, Input = Output> {
   // Alias for toJsonSchema (for compatibility)
   json(): Record<string, any> {
     return this.toJsonSchema();
+  }
+
+  // Getter for AI SDK compatibility (Vercel AI SDK expects .jsonSchema)
+  get jsonSchema(): Record<string, any> {
+    return this.toJsonSchema();
+  }
+
+  // AI SDK compatibility: validate function (expected by isSchema check)
+  validate(value: unknown): SafeParseResult<Output> {
+    return this.safeParse(value);
   }
 
   // Override in subclasses to provide type-specific schema


### PR DESCRIPTION
## Summary

- Add native Vercel AI SDK compatibility to dhi schemas
- Schemas now pass the AI SDK's `isSchema()` check without needing wrappers
- Implements `Symbol.for("vercel.ai.schema")` marker, `jsonSchema` getter, and `validate()` function

## Problem

When passing dhi schemas to the AI SDK's `tool()` function, the SDK couldn't recognize them:

```typescript
// This didn't work - AI SDK tried to use zod-to-json-schema
tool({
  parameters: z.object({ query: z.string() }),  // ❌ Error: def.typeName undefined
  execute: async (args) => { ... }
})
```

The AI SDK's `asSchema()` function checks for the `Symbol.for("vercel.ai.schema")` marker. Without it, schemas are passed to `zod-to-json-schema` which expects Zod's internal `_def.typeName` structure.

## Solution

Added three properties to the `DhiType` base class:

1. `[Symbol.for("vercel.ai.schema")]` = true - AI SDK marker
2. `get jsonSchema()` - Returns JSON Schema (already had `toJsonSchema()`)
3. `validate(value)` - Wraps `safeParse()` for AI SDK compatibility

## Usage

```typescript
import { tool } from 'ai';
import { z } from 'dhi';

// Now works directly - no wrapper needed!
const weatherTool = tool({
  parameters: z.object({
    location: z.string().min(1),
    unit: z.enum(['celsius', 'fahrenheit']),
  }),
  execute: async ({ location, unit }) => {
    return { location, temperature: 72, unit };
  }
});
```

## Test Plan

- [x] All 77 Zod 4 compatibility tests pass
- [x] AI SDK `isSchema()` check passes for all schema types
- [x] `jsonSchema` getter returns correct JSON Schema
- [x] `validate()` function works correctly
- [x] AI SDK demo runs without `def.typeName` error