### PR TITLE
feat(js): Add Vercel AI SDK compatibility for dhi schemas

### DIFF
--- a/js-bindings/examples/ai-sdk-tools/test-ai-sdk-compat.ts
+++ b/js-bindings/examples/ai-sdk-tools/test-ai-sdk-compat.ts
@@ -1,0 +1,104 @@
+/**
+ * Test: Verify dhi's full AI SDK compatibility
+ *
+ * The AI SDK's isSchema() check requires:
+ * 1. Symbol.for("vercel.ai.schema") === true
+ * 2. "jsonSchema" property exists
+ * 3. "validate" property exists
+ */
+import { z } from '../../schema';
+
+const schemaSymbol = Symbol.for("vercel.ai.schema");
+
+// AI SDK's isSchema function (copied from @ai-sdk/ui-utils)
+function isSchema(value: any): boolean {
+  return typeof value === "object" &&
+    value !== null &&
+    schemaSymbol in value &&
+    value[schemaSymbol] === true &&
+    "jsonSchema" in value &&
+    "validate" in value;
+}
+
+console.log('='.repeat(60));
+console.log('  Testing dhi AI SDK Full Compatibility');
+console.log('='.repeat(60));
+console.log('');
+
+const UserSchema = z.object({
+  name: z.string().min(1).describe("User's name"),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+});
+
+// Test 1: Symbol marker exists
+console.log('Test 1: Symbol.for("vercel.ai.schema") marker');
+const hasSymbol = schemaSymbol in UserSchema;
+const symbolValue = hasSymbol ? (UserSchema as any)[schemaSymbol] : undefined;
+console.log('  Has symbol:', hasSymbol);
+console.log('  Symbol value:', symbolValue);
+console.log('  Result:', symbolValue === true ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 2: jsonSchema getter exists
+console.log('Test 2: jsonSchema getter');
+const hasJsonSchema = 'jsonSchema' in UserSchema;
+const jsonSchema = (UserSchema as any).jsonSchema;
+console.log('  Has jsonSchema:', hasJsonSchema);
+console.log('  jsonSchema type:', typeof jsonSchema);
+console.log('  Result:', hasJsonSchema && typeof jsonSchema === 'object' ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 3: validate function exists
+console.log('Test 3: validate function');
+const hasValidate = 'validate' in UserSchema;
+const validate = (UserSchema as any).validate;
+console.log('  Has validate:', hasValidate);
+console.log('  validate type:', typeof validate);
+console.log('  Result:', hasValidate && typeof validate === 'function' ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 4: validate function works correctly
+console.log('Test 4: validate function works');
+const validData = { name: 'Alice', email: 'alice@example.com', age: 25 };
+const invalidData = { name: '', email: 'invalid', age: -5 };
+
+const validResult = validate.call(UserSchema, validData);
+const invalidResult = validate.call(UserSchema, invalidData);
+
+console.log('  Valid data result:', validResult.success);
+console.log('  Invalid data result:', invalidResult.success);
+console.log('  Result:', validResult.success === true && invalidResult.success === false ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 5: isSchema() function passes
+console.log('Test 5: AI SDK isSchema() check');
+const passesIsSchema = isSchema(UserSchema);
+console.log('  isSchema(UserSchema):', passesIsSchema);
+console.log('  Result:', passesIsSchema ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 6: Test with various schema types
+console.log('Test 6: Various schema types pass isSchema()');
+const schemas = [
+  { name: 'z.string()', schema: z.string() },
+  { name: 'z.number()', schema: z.number() },
+  { name: 'z.boolean()', schema: z.boolean() },
+  { name: 'z.array(z.string())', schema: z.array(z.string()) },
+  { name: 'z.enum(["a", "b"])', schema: z.enum(['a', 'b']) },
+  { name: 'z.object({}).optional()', schema: z.object({}).optional() },
+  { name: 'z.union([z.string(), z.number()])', schema: z.union([z.string(), z.number()]) },
+];
+
+let allPass = true;
+for (const { name, schema } of schemas) {
+  const passes = isSchema(schema);
+  console.log(`  ${name}: ${passes ? '✅' : '❌'}`);
+  if (!passes) allPass = false;
+}
+console.log('  Result:', allPass ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+console.log('='.repeat(60));
+console.log('  All compatibility tests completed!');
+console.log('='.repeat(60));

--- a/js-bindings/examples/ai-sdk-tools/test-jsonschema-getter.ts
+++ b/js-bindings/examples/ai-sdk-tools/test-jsonschema-getter.ts
@@ -1,0 +1,63 @@
+/**
+ * Test: Verify dhi's jsonSchema getter for AI SDK compatibility
+ */
+import { z } from '../../schema';
+
+// Test basic schema
+const UserSchema = z.object({
+  name: z.string().min(1).describe("User's name"),
+  email: z.string().email(),
+  age: z.number().int().positive(),
+});
+
+console.log('='.repeat(60));
+console.log('  Testing dhi jsonSchema getter for AI SDK compatibility');
+console.log('='.repeat(60));
+console.log('');
+
+// Test 1: jsonSchema getter exists
+console.log('Test 1: jsonSchema getter exists');
+console.log('  typeof UserSchema.jsonSchema:', typeof UserSchema.jsonSchema);
+console.log('  Result:', typeof UserSchema.jsonSchema === 'object' ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 2: jsonSchema returns valid schema
+console.log('Test 2: jsonSchema returns valid JSON Schema');
+const schema = UserSchema.jsonSchema;
+console.log('  schema.type:', schema.type);
+console.log('  schema.properties:', Object.keys(schema.properties || {}));
+console.log('  Result:', schema.type === 'object' ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 3: Same as toJsonSchema()
+console.log('Test 3: jsonSchema getter matches toJsonSchema() method');
+const method = UserSchema.toJsonSchema();
+const getter = UserSchema.jsonSchema;
+const matches = JSON.stringify(method) === JSON.stringify(getter);
+console.log('  Matches:', matches ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 4: Works with nested schemas
+const ComplexSchema = z.object({
+  user: z.object({
+    name: z.string(),
+    role: z.enum(['admin', 'user']),
+  }),
+  items: z.array(z.number()),
+});
+
+console.log('Test 4: Works with nested schemas');
+const complexJsonSchema = ComplexSchema.jsonSchema;
+console.log('  Has user property:', 'user' in (complexJsonSchema.properties || {}));
+console.log('  Has items property:', 'items' in (complexJsonSchema.properties || {}));
+console.log('  Result:', complexJsonSchema.type === 'object' ? '✅ PASS' : '❌ FAIL');
+console.log('');
+
+// Test 5: Output the full schema
+console.log('Test 5: Full JSON Schema output');
+console.log(JSON.stringify(UserSchema.jsonSchema, null, 2));
+console.log('');
+
+console.log('='.repeat(60));
+console.log('  All tests completed!');
+console.log('='.repeat(60));

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -425,6 +425,11 @@ export abstract class DhiType<Output = any, Input = Output> {
     return this.toJsonSchema();
   }
 
+  // Getter for AI SDK compatibility - Vercel AI SDK expects .jsonSchema property
+  get jsonSchema(): Record<string, any> {
+    return this.toJsonSchema();
+  }
+
   // Override in subclasses to provide type-specific schema
   protected _toJsonSchemaCore(): Record<string, any> {
     return {};

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -267,11 +267,17 @@ export type SafeParseResult<T> =
 // Base Schema Type
 // ============================================================================
 
+// AI SDK compatibility symbol - allows Vercel AI SDK to detect dhi schemas
+const schemaSymbol = Symbol.for("vercel.ai.schema");
+
 export abstract class DhiType<Output = any, Input = Output> {
   readonly _output!: Output;
   readonly _input!: Input;
   _description?: string;
   _metadata?: Record<string, any>;
+
+  // AI SDK compatibility marker - enables isSchema() detection
+  readonly [schemaSymbol] = true;
 
   abstract _parse(value: unknown, path: (string | number)[]): SafeParseResult<Output>;
 

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -430,6 +430,11 @@ export abstract class DhiType<Output = any, Input = Output> {
     return this.toJsonSchema();
   }
 
+  // AI SDK compatibility: validate function expected by isSchema() check
+  validate(value: unknown): SafeParseResult<Output> {
+    return this.safeParse(value);
+  }
+
   // Override in subclasses to provide type-specific schema
   protected _toJsonSchemaCore(): Record<string, any> {
     return {};


### PR DESCRIPTION
## Summary

This PR adds full Vercel AI SDK compatibility to dhi schemas, enabling them to work directly with AI SDK's `tool()` function without any wrapper functions.

### Changes

**Core Features:**
- Added `Symbol.for("vercel.ai.schema")` marker for AI SDK schema detection
- Added `jsonSchema` getter that returns JSON Schema representation
- Added `validate()` method that wraps `safeParse()` for AI SDK interface

**Tests:**
- Comprehensive AI SDK `isSchema()` compatibility test suite
- JSON Schema getter verification tests

### Why This Matters

**Before:** Users had to manually wrap dhi schemas:
```typescript
import { tool, jsonSchema } from "ai"
import { z } from "dhi"

tool({
  inputSchema: jsonSchema(schema.toJsonSchema()),  // ❌ Verbose wrapper needed
  execute: async (args) => { ... }
})
```

**After:** dhi schemas work directly:
```typescript
import { tool } from "ai"
import { z } from "dhi"

tool({
  inputSchema: schema,  // ✅ Works directly!
  execute: async (args) => { ... }
})
```

### Technical Details

The AI SDK's `isSchema()` function checks for three things:
1. `Symbol.for("vercel.ai.schema") === true` ✅
2. `jsonSchema` property exists ✅
3. `validate` function exists ✅

All three are now implemented in dhi's `DhiType` base class, so all schema types (string, number, object, array, etc.) inherit AI SDK compatibility.

## Test plan

- [x] All 77 Zod4 compatibility tests pass
- [x] AI SDK `isSchema()` compatibility tests pass
- [x] JSON Schema getter tests pass
- [x] Build succeeds
- [ ] CI pipeline passes