### PR TITLE
chore: Bump version to 1.1.19

### DIFF
--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.1.18"
+__version__ = "1.1.19"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.1.18"
+version = "1.1.19"
 description = "Ultra-fast data validation for Python - 28M validations/sec, 3x faster than Rust alternatives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bump version to 1.1.19 for both packages:
- **npm (dhi)**: 1.1.18 → 1.1.19
- **PyPI (dhi)**: 1.1.18 → 1.1.19

## Changes

- `js-bindings/package.json`
- `python-bindings/pyproject.toml`
- `python-bindings/dhi/__init__.py`

🤖 Generated with [Claude Code](https://claude.ai/code)