### PR TITLE
fix: Update GitHub Release action to v2

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,12 +69,9 @@ jobs:
       
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: dhi ${{ github.ref_name }}
+          name: dhi ${{ github.ref_name }}
           body: |
             ## dhi ${{ github.ref_name }}
 


### PR DESCRIPTION
## Summary

Fix the failing GitHub Release step in the npm publish workflow.

## Changes

- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Add `permissions: contents: write` block for proper access

## Why

The old action was failing with:
```
Error: Resource not accessible by integration
```

🤖 Generated with [Claude Code](https://claude.ai/code)