### PR TITLE
feat: Add Standard Schema v1 support for AI SDK compatibility

### DIFF
--- a/js-bindings/schema-nextjs-edge.ts
+++ b/js-bindings/schema-nextjs-edge.ts
@@ -282,11 +282,44 @@ export type SafeParseResult<T> =
 // Base Schema Type
 // ============================================================================
 
+// AI SDK compatibility symbol - allows Vercel AI SDK to detect dhi schemas
+const schemaSymbol = Symbol.for("vercel.ai.schema");
+
 export abstract class DhiType<Output = any, Input = Output> {
   readonly _output!: Output;
   readonly _input!: Input;
   _description?: string;
   _metadata?: Record<string, any>;
+
+  // AI SDK compatibility marker - enables isSchema() detection
+  readonly [schemaSymbol] = true;
+
+  // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
+  // See: https://github.com/standard-schema/standard-schema
+  get '~standard'(): {
+    version: 1;
+    vendor: 'dhi';
+    validate: (value: unknown) => Promise<{ value: Output } | { issues: Array<{ message: string; path?: Array<string | number> }> }>;
+    types?: { input: Input; output: Output };
+  } {
+    return {
+      version: 1,
+      vendor: 'dhi',
+      validate: async (value: unknown) => {
+        const result = this.safeParse(value);
+        if (result.success) {
+          return { value: result.data };
+        }
+        return {
+          issues: result.error.issues.map(issue => ({
+            message: issue.message,
+            path: issue.path,
+          })),
+        };
+      },
+      types: undefined as any, // Type-level only, no runtime value needed
+    };
+  }
 
   abstract _parse(value: unknown, path: (string | number)[]): SafeParseResult<Output>;
 

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -279,6 +279,33 @@ export abstract class DhiType<Output = any, Input = Output> {
   // AI SDK compatibility marker - enables isSchema() detection
   readonly [schemaSymbol] = true;
 
+  // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
+  // See: https://github.com/standard-schema/standard-schema
+  get '~standard'(): {
+    version: 1;
+    vendor: 'dhi';
+    validate: (value: unknown) => Promise<{ value: Output } | { issues: Array<{ message: string; path?: Array<string | number> }> }>;
+    types?: { input: Input; output: Output };
+  } {
+    return {
+      version: 1,
+      vendor: 'dhi',
+      validate: async (value: unknown) => {
+        const result = this.safeParse(value);
+        if (result.success) {
+          return { value: result.data };
+        }
+        return {
+          issues: result.error.issues.map(issue => ({
+            message: issue.message,
+            path: issue.path,
+          })),
+        };
+      },
+      types: undefined as any, // Type-level only, no runtime value needed
+    };
+  }
+
   abstract _parse(value: unknown, path: (string | number)[]): SafeParseResult<Output>;
 
   parse(value: unknown): Output {


### PR DESCRIPTION
## Summary

Implements the Standard Schema v1 interface (`~standard` property) on all dhi schema types, enabling seamless integration with Vercel AI SDK and other tools that support the Standard Schema spec.

## Problem

Users were getting type errors when using dhi schemas with Vercel AI SDK:

```
Type 'DhiObject<...>' is not assignable to type 'ZodType<any, ZodTypeDef, any> | $ZodType<...> | Schema | undefined'.
Type 'DhiObject<...>' is missing the following properties from type 'ZodType<any, ZodTypeDef, any>': _type, _def, description, "~standard", and 10 more.
```

## Solution

Add the Standard Schema v1 interface to the `DhiType` base class:

```typescript
get '~standard'() {
  return {
    version: 1,
    vendor: 'dhi',
    validate: async (value) => {
      const result = this.safeParse(value);
      if (result.success) {
        return { value: result.data };
      }
      return { issues: result.error.issues.map(...) };
    },
    types: undefined as any,
  };
}
```

## Changes

- `schema.ts` - Add `~standard` getter
- `schema-cloudflare.ts` - Add `~standard` getter + schemaSymbol
- `schema-edge.ts` - Add `~standard` getter + schemaSymbol  
- `schema-nextjs-edge.ts` - Auto-generated with changes

## Usage with AI SDK

```typescript
import { z } from 'dhi';
import { tool } from 'ai';

const myTool = tool({
  description: 'Check threat',
  parameters: z.object({
    reason: z.string(),
    threatFlag: z.boolean(),
  }),
  execute: async ({ reason, threatFlag }) => {
    // ...
  },
});
```

## Test plan

- [x] `~standard.version` returns `1`
- [x] `~standard.vendor` returns `'dhi'`
- [x] `~standard.validate()` returns correct format for valid/invalid inputs
- [x] AI SDK schemaSymbol compatibility marker exists
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)