### PR TITLE
feat: Add Zod compatibility aliases and bump to v1.1.20

### DIFF
--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/js-bindings/schema-cloudflare.ts
+++ b/js-bindings/schema-cloudflare.ts
@@ -277,6 +277,31 @@ export abstract class DhiType<Output = any, Input = Output> {
   // AI SDK compatibility marker - enables isSchema() detection
   readonly [schemaSymbol] = true;
 
+  // Zod compatibility: _def property (schema definition)
+  // Returns a Zod-like definition object for compatibility with tools expecting Zod schemas
+  get _def(): { typeName: string; description?: string } {
+    return {
+      typeName: this.constructor.name.replace('Dhi', 'Zod'),
+      description: this._description,
+    };
+  }
+
+  // Zod v4 compatibility: def property (alias for _def)
+  get def(): { typeName: string; description?: string } {
+    return this._def;
+  }
+
+  // Zod compatibility: _type property (inferred output type marker)
+  // This is a type-level property in Zod, we provide it for structural compatibility
+  get _type(): Output {
+    return undefined as any;
+  }
+
+  // Zod compatibility: description getter
+  get description(): string | undefined {
+    return this._description;
+  }
+
   // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
   // See: https://github.com/standard-schema/standard-schema
   get '~standard'(): {

--- a/js-bindings/schema-edge.ts
+++ b/js-bindings/schema-edge.ts
@@ -277,6 +277,31 @@ export abstract class DhiType<Output = any, Input = Output> {
   // AI SDK compatibility marker - enables isSchema() detection
   readonly [schemaSymbol] = true;
 
+  // Zod compatibility: _def property (schema definition)
+  // Returns a Zod-like definition object for compatibility with tools expecting Zod schemas
+  get _def(): { typeName: string; description?: string } {
+    return {
+      typeName: this.constructor.name.replace('Dhi', 'Zod'),
+      description: this._description,
+    };
+  }
+
+  // Zod v4 compatibility: def property (alias for _def)
+  get def(): { typeName: string; description?: string } {
+    return this._def;
+  }
+
+  // Zod compatibility: _type property (inferred output type marker)
+  // This is a type-level property in Zod, we provide it for structural compatibility
+  get _type(): Output {
+    return undefined as any;
+  }
+
+  // Zod compatibility: description getter
+  get description(): string | undefined {
+    return this._description;
+  }
+
   // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
   // See: https://github.com/standard-schema/standard-schema
   get '~standard'(): {

--- a/js-bindings/schema-nextjs-edge.ts
+++ b/js-bindings/schema-nextjs-edge.ts
@@ -294,6 +294,31 @@ export abstract class DhiType<Output = any, Input = Output> {
   // AI SDK compatibility marker - enables isSchema() detection
   readonly [schemaSymbol] = true;
 
+  // Zod compatibility: _def property (schema definition)
+  // Returns a Zod-like definition object for compatibility with tools expecting Zod schemas
+  get _def(): { typeName: string; description?: string } {
+    return {
+      typeName: this.constructor.name.replace('Dhi', 'Zod'),
+      description: this._description,
+    };
+  }
+
+  // Zod v4 compatibility: def property (alias for _def)
+  get def(): { typeName: string; description?: string } {
+    return this._def;
+  }
+
+  // Zod compatibility: _type property (inferred output type marker)
+  // This is a type-level property in Zod, we provide it for structural compatibility
+  get _type(): Output {
+    return undefined as any;
+  }
+
+  // Zod compatibility: description getter
+  get description(): string | undefined {
+    return this._description;
+  }
+
   // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
   // See: https://github.com/standard-schema/standard-schema
   get '~standard'(): {

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -279,6 +279,31 @@ export abstract class DhiType<Output = any, Input = Output> {
   // AI SDK compatibility marker - enables isSchema() detection
   readonly [schemaSymbol] = true;
 
+  // Zod compatibility: _def property (schema definition)
+  // Returns a Zod-like definition object for compatibility with tools expecting Zod schemas
+  get _def(): { typeName: string; description?: string } {
+    return {
+      typeName: this.constructor.name.replace('Dhi', 'Zod'),
+      description: this._description,
+    };
+  }
+
+  // Zod v4 compatibility: def property (alias for _def)
+  get def(): { typeName: string; description?: string } {
+    return this._def;
+  }
+
+  // Zod compatibility: _type property (inferred output type marker)
+  // This is a type-level property in Zod, we provide it for structural compatibility
+  get _type(): Output {
+    return undefined as any;
+  }
+
+  // Zod compatibility: description getter
+  get description(): string | undefined {
+    return this._description;
+  }
+
   // Standard Schema v1 compatibility - allows AI SDK and other tools to use dhi schemas
   // See: https://github.com/standard-schema/standard-schema
   get '~standard'(): {

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.1.19"
+__version__ = "1.1.20"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.1.19"
+version = "1.1.20"
 description = "Ultra-fast data validation for Python - 28M validations/sec, 3x faster than Rust alternatives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Adds Zod-compatible properties to `DhiType` for better interoperability with tools that expect Zod schemas (like Vercel AI SDK).

## Changes

### Zod Compatibility Aliases

| Property | Description |
|----------|-------------|
| `_def` | Returns `{ typeName, description }` like Zod |
| `def` | Zod v4 alias for `_def` |
| `_type` | Type-level output marker |
| `description` | Getter for schema description |
| `~standard` | Standard Schema v1 interface (from PR #34) |

### Version Bump

- npm (dhi): 1.1.19 → **1.1.20**
- PyPI (dhi): 1.1.19 → **1.1.20**

## Example

```typescript
import { z } from 'dhi';

const schema = z.object({ name: z.string() });

// These all work now:
schema._def.typeName  // "ZodObject"
schema.def.typeName   // "ZodObject" 
schema._type          // type-level marker
schema.description    // undefined or string
schema['~standard']   // Standard Schema v1 interface
```

## Test plan

- [x] `_def` returns correct typeName
- [x] `def` alias works
- [x] `_type` exists
- [x] `description` getter works
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)