### PR TITLE
fix: Export z.ZodType in namespace for Zod API parity

### DIFF
--- a/js-bindings/README.md
+++ b/js-bindings/README.md
@@ -230,7 +230,7 @@ type Post = z.infer<typeof PostSchema>;
 ### Same error handling
 
 ```typescript
-import { z, ZodError } from 'dhi/schema';
+import { z, ZodError } from 'dhi';
 
 try {
   schema.parse(badData);

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/js-bindings/schema-cloudflare.ts
+++ b/js-bindings/schema-cloudflare.ts
@@ -2574,6 +2574,7 @@ export namespace z {
   export type infer<T extends DhiType<any, any>> = T["_output"];
   export type input<T extends DhiType<any, any>> = T["_input"];
   export type output<T extends DhiType<any, any>> = T["_output"];
+  export type ZodType<Output = any, Input = Output> = DhiType<Output, Input>;
 }
 
 // Also export as `d` for dhi-native usage

--- a/js-bindings/schema-edge.ts
+++ b/js-bindings/schema-edge.ts
@@ -2574,6 +2574,7 @@ export namespace z {
   export type infer<T extends DhiType<any, any>> = T["_output"];
   export type input<T extends DhiType<any, any>> = T["_input"];
   export type output<T extends DhiType<any, any>> = T["_output"];
+  export type ZodType<Output = any, Input = Output> = DhiType<Output, Input>;
 }
 
 // Also export as `d` for dhi-native usage

--- a/js-bindings/schema-nextjs-edge.ts
+++ b/js-bindings/schema-nextjs-edge.ts
@@ -2591,6 +2591,7 @@ export namespace z {
   export type infer<T extends DhiType<any, any>> = T["_output"];
   export type input<T extends DhiType<any, any>> = T["_input"];
   export type output<T extends DhiType<any, any>> = T["_output"];
+  export type ZodType<Output = any, Input = Output> = DhiType<Output, Input>;
 }
 
 // Also export as `d` for dhi-native usage

--- a/js-bindings/schema.ts
+++ b/js-bindings/schema.ts
@@ -2586,6 +2586,7 @@ export namespace z {
   export type infer<T extends DhiType<any, any>> = T["_output"];
   export type input<T extends DhiType<any, any>> = T["_input"];
   export type output<T extends DhiType<any, any>> = T["_output"];
+  export type ZodType<Output = any, Input = Output> = DhiType<Output, Input>;
 }
 
 // Also export as `d` for dhi-native usage

--- a/js-bindings/tsconfig.json
+++ b/js-bindings/tsconfig.json
@@ -24,5 +24,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["*.ts", "packages/dhi-sdk/src/**/*.ts"],
+  "exclude": ["node_modules", "examples", "packages/dhi-sdk/complex-sdk", "packages/dhi-sdk/my-sdk"]
 }


### PR DESCRIPTION
## Summary

- **Export `z.ZodType`** in the `z` namespace across all schema variants (`schema.ts`, `schema-edge.ts`, `schema-cloudflare.ts`, `schema-nextjs-edge.ts`). Previously `ZodType` was only available as a top-level module export (`import type { ZodType } from "dhi"`), but not via `z.ZodType<T>` which is the common Zod pattern.
- **Fix stale import** in README.md: `dhi/schema` → `dhi`
- **Bump to v1.1.22**

## Why

Common Zod usage like typing a generic `schema` parameter:

```ts
private async request<T>(schema: z.ZodType<T>): Promise<T> {
  // ...
  return schema.parse(data);
}
```

would fail with dhi because `z.ZodType` didn't exist in the namespace. Users had to use a structural workaround (`{ parse(data: unknown): T }`) instead.

## Test plan

- [x] `tsc --noEmit -p tsconfig.build.json` passes clean
- [ ] Verify `z.ZodType<T>` works in downstream consumer code


🤖 Generated with [Claude Code](https://claude.com/claude-code)