### PR TITLE
feat: Add build.zig.zon for Zig package manager support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -74,15 +74,13 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/model.zig"),
     });
 
-    // Export module for use as a dependency
-    const satya_module = b.addModule("satya", .{
+    // Export module for use as a dependency (no target/optimize — inherited from consumer)
+    const dhi_module = b.addModule("dhi", .{
         .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
     });
-    satya_module.addImport("validator", validator_mod);
-    satya_module.addImport("combinators", combinators_mod);
-    satya_module.addImport("json_validator", json_validator_mod);
+    dhi_module.addImport("validator", validator_mod);
+    dhi_module.addImport("combinators", combinators_mod);
+    dhi_module.addImport("json_validator", json_validator_mod);
 
     // Example: basic_usage
     const basic_example = b.addExecutable(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = .dhi,
+    .fingerprint = 0x29d582bd9fdb3d17,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.15.0",
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
+    },
+}


### PR DESCRIPTION
## Summary

Adds `build.zig.zon` so dhi can be used as a Zig library dependency via the Zig package manager.

## Changes

- **`build.zig.zon`** — New manifest with `name = .dhi`, `version = "0.1.0"`, `minimum_zig_version = "0.15.0"`, and fingerprint
- **`build.zig`** — Renamed exported module from `satya` to `dhi`; removed hardcoded `target`/`optimize` from the dependency module (inherited from consumer)

## Usage

Downstream projects can now:
```bash
zig fetch --save https://github.com/justrach/dhi/archive/refs/tags/v0.1.0.tar.gz
```
```zig
// consumer's build.zig
const dhi_dep = b.dependency("dhi", .{});
exe.root_module.addImport("dhi", dhi_dep.module("dhi"));
```

## Review Notes

- No existing downstream Zig consumers, so `satya` → `dhi` rename is non-breaking
- `zig build` and `zig build test` both pass