### PR TITLE
refactor: complete satya→dhi rename across C ABI, build system, and all docs

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           name: zig-lib-${{ matrix.arch }}
           path: |
-            zig-out/lib/libsatya.*
-            zig-out/lib/satya.*
+            zig-out/lib/libdhi.*
+            zig-out/lib/dhi.*
           retention-days: 1
 
   build_wheels:
@@ -83,7 +83,7 @@ jobs:
         run: |
           echo "Zig library for ${{ matrix.arch }}:"
           ls -la zig-out/lib/
-          file zig-out/lib/libsatya.* || true
+          file zig-out/lib/libdhi.* || true
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3

--- a/ADR.md
+++ b/ADR.md
@@ -89,8 +89,8 @@ enum ValidatorType type = parse_validator_type(type_str);
 
 // Dispatch with O(1) switch
 switch (type) {
-    case VAL_EMAIL: return satya_validate_email(value);
-    case VAL_URL: return satya_validate_url(value);
+    case VAL_EMAIL: return dhi_validate_email(value);
+    case VAL_URL: return dhi_validate_url(value);
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ bun run bench                       # Run benchmark (vs Zod)
 ### Zig (rebuild native libs)
 ```bash
 zig build -Doptimize=ReleaseFast    # Build optimized
-cp zig-out/lib/libsatya.dylib python-bindings/dhi/
+cp zig-out/lib/libdhi.dylib python-bindings/dhi/
 ```
 
 ### Python C Extension (rebuild)
@@ -65,7 +65,7 @@ python setup.py build_ext --inplace
 
 ### Python Path
 ```
-Python → _dhi_native.so (C) → libsatya.dylib (Zig) → SIMD validators
+Python → _dhi_native.so (C) → libdhi.dylib (Zig) → SIMD validators
               ↓
     Pre-compiled field specs (zero per-call overhead)
 ```
@@ -154,6 +154,6 @@ cd js-bindings && bun test-zod4-compat.ts
 
 ## Links
 
-- **GitHub**: https://github.com/justrach/satya-zig
+- **GitHub**: https://github.com/justrach/dhi
 - **PyPI**: https://pypi.org/project/dhi/
 - **npm**: https://www.npmjs.com/package/dhi

--- a/DOCS.md
+++ b/DOCS.md
@@ -27,8 +27,8 @@ pip install dhi
 ### From Source
 
 ```bash
-git clone https://github.com/justrach/satya-zig.git
-cd satya-zig
+git clone https://github.com/justrach/dhi.git
+cd dhi
 zig build -Doptimize=ReleaseFast
 cd python-bindings
 pip install -e .
@@ -419,8 +419,8 @@ A: Yes! Thoroughly tested and benchmarked. Used in production systems.
 
 ## Support
 
-- **GitHub Issues**: https://github.com/justrach/satya-zig/issues
-- **Documentation**: https://github.com/justrach/satya-zig/blob/main/DOCS.md
+- **GitHub Issues**: https://github.com/justrach/dhi/issues
+- **Documentation**: https://github.com/justrach/dhi/blob/main/DOCS.md
 - **PyPI**: https://pypi.org/project/dhi/
 
 ---
@@ -512,10 +512,10 @@ Created `src/batch_validator.zig` with:
 ### 2. Exposed via C API
 
 Added to `src/c_api.zig`:
-- `satya_validate_users_batch_optimized`
-- `satya_validate_int_batch_simd`
-- `satya_validate_string_length_batch`
-- `satya_validate_email_batch`
+- `dhi_validate_users_batch_optimized`
+- `dhi_validate_int_batch_simd`
+- `dhi_validate_string_length_batch`
+- `dhi_validate_email_batch`
 
 ### 3. Created Python Bindings
 
@@ -945,8 +945,8 @@ Step 1: Build Zig Library
            │ zig build -Doptimize=ReleaseFast
            ↓
 ┌──────────────────────┐
-│ libsatya.dylib       │  ← Shared library (macOS)
-│ libsatya.so          │  ← Shared library (Linux)
+│ libdhi.dylib       │  ← Shared library (macOS)
+│ libdhi.so          │  ← Shared library (Linux)
 └──────────┬───────────┘
            │
            │
@@ -956,11 +956,11 @@ Step 2: Build C Extension
 │  dhi/_native.c       │  ← CPython C extension source
 │  - PyInit_dhi_native │
 │  - py_validate_int() │
-│  - Links: libsatya   │
+│  - Links: libdhi   │
 └──────────┬───────────┘
            │ pip install -e . (runs setup.py)
            │ gcc -shared -fPIC -I/python/include
-           │     -L../zig-out/lib -lsatya
+           │     -L../zig-out/lib -ldhi
            ↓
 ┌──────────────────────┐
 │ _dhi_native.so       │  ← Compiled C extension
@@ -992,7 +992,7 @@ zig build -Doptimize=ReleaseFast
 2. Finds C library definition:
    ```zig
    const c_lib = b.addLibrary(.{
-       .name = "satya",
+       .name = "dhi",
        .root_module = b.createModule(.{
            .root_source_file = b.path("src/c_api.zig"),
            .target = target,
@@ -1003,16 +1003,16 @@ zig build -Doptimize=ReleaseFast
    ```
 3. Compiles `src/c_api.zig` with exported functions:
    ```zig
-   export fn satya_validate_int(value: i64, min: i64, max: i64) i32 {
+   export fn dhi_validate_int(value: i64, min: i64, max: i64) i32 {
        if (value < min or value > max) return 0;
        return 1;
    }
    ```
-4. Creates `zig-out/lib/libsatya.dylib` (or `.so` on Linux)
+4. Creates `zig-out/lib/libdhi.dylib` (or `.so` on Linux)
 
 **Output:**
-- `libsatya.dylib` - Shared library with C ABI
-- Exports: `satya_validate_int`, `satya_validate_email`, etc.
+- `libdhi.dylib` - Shared library with C ABI
+- Exports: `dhi_validate_int`, `dhi_validate_email`, etc.
 - Size: ~49KB (optimized)
 
 ### Step 2: Build CPython C Extension
@@ -1031,29 +1031,29 @@ pip install -e .
        'dhi._dhi_native',
        sources=['dhi/_native.c'],
        library_dirs=[str(zig_lib_path)],
-       libraries=['satya'],  # ← Links against libsatya
+       libraries=['dhi'],  # ← Links against libdhi
        extra_compile_args=['-O3'],
    )
    ```
 3. Compiles `dhi/_native.c`:
    ```c
    // External Zig functions
-   extern int satya_validate_int(long value, long min, long max);
+   extern int dhi_validate_int(long value, long min, long max);
    
    // Python wrapper
    static PyObject* py_validate_int(PyObject* self, PyObject* args) {
        long value, min, max;
        PyArg_ParseTuple(args, "lll", &value, &min, &max);
-       int result = satya_validate_int(value, min, max);
+       int result = dhi_validate_int(value, min, max);
        return PyBool_FromLong(result);
    }
    ```
-4. Links against `libsatya.dylib`
+4. Links against `libdhi.dylib`
 5. Creates `_dhi_native.cpython-313t-darwin.so`
 
 **Output:**
 - `_dhi_native.so` - CPython extension module
-- Imports: `libsatya.dylib` functions
+- Imports: `libdhi.dylib` functions
 - Size: ~16KB
 
 ### Step 3: Python Runtime
@@ -1082,7 +1082,7 @@ age = Age.validate(25)
        if not _dhi_native.validate_int(value, self.min_val, self.max_val):
            raise ValidationError(...)
    ```
-4. `_dhi_native.validate_int()` calls Zig's `satya_validate_int()`
+4. `_dhi_native.validate_int()` calls Zig's `dhi_validate_int()`
 5. Result returned to Python
 
 **Call stack:**
@@ -1093,7 +1093,7 @@ Python: _dhi_native.validate_int(25, 18, 90)
     ↓ (C extension - 55ns overhead)
 C: py_validate_int()
     ↓
-C: satya_validate_int(25, 18, 90)
+C: dhi_validate_int(25, 18, 90)
     ↓ (Zig code - 0ns overhead)
 Zig: if (value < min or value > max) return 0; return 1;
     ↓
@@ -1139,10 +1139,10 @@ Total time per validation: 121.7ns
 ### ctypes (Previous Approach)
 ```python
 # Load library
-lib = ctypes.CDLL('libsatya.dylib')
+lib = ctypes.CDLL('libdhi.dylib')
 
 # Call function
-result = lib.satya_validate_int(value, min, max)
+result = lib.dhi_validate_int(value, min, max)
 ```
 
 **Overhead:** ~150ns per call
@@ -1213,7 +1213,7 @@ This ensures the package works everywhere, even without Zig or C compiler!
 ls python-bindings/dhi/_dhi_native*.so
 
 # Check if Zig library exists
-ls zig-out/lib/libsatya.*
+ls zig-out/lib/libdhi.*
 
 # Verify import
 python -c "from dhi import _dhi_native; print('OK')"
@@ -1315,31 +1315,31 @@ All validators are exposed via C API for Python bindings:
 
 ```c
 // String validators
-extern int satya_validate_email(const char* str);
-extern int satya_validate_url(const char* str);
-extern int satya_validate_uuid(const char* str);
-extern int satya_validate_ipv4(const char* str);
-extern int satya_validate_base64(const char* str);
-extern int satya_validate_iso_date(const char* str);
-extern int satya_validate_iso_datetime(const char* str);
-extern int satya_validate_contains(const char* str, const char* substring);
-extern int satya_validate_starts_with(const char* str, const char* prefix);
-extern int satya_validate_ends_with(const char* str, const char* suffix);
+extern int dhi_validate_email(const char* str);
+extern int dhi_validate_url(const char* str);
+extern int dhi_validate_uuid(const char* str);
+extern int dhi_validate_ipv4(const char* str);
+extern int dhi_validate_base64(const char* str);
+extern int dhi_validate_iso_date(const char* str);
+extern int dhi_validate_iso_datetime(const char* str);
+extern int dhi_validate_contains(const char* str, const char* substring);
+extern int dhi_validate_starts_with(const char* str, const char* prefix);
+extern int dhi_validate_ends_with(const char* str, const char* suffix);
 
 // Number validators
-extern int satya_validate_int_gt(long value, long min);
-extern int satya_validate_int_gte(long value, long min);
-extern int satya_validate_int_lt(long value, long max);
-extern int satya_validate_int_lte(long value, long max);
-extern int satya_validate_int_positive(long value);
-extern int satya_validate_int_non_negative(long value);
-extern int satya_validate_int_negative(long value);
-extern int satya_validate_int_non_positive(long value);
-extern int satya_validate_int_multiple_of(long value, long divisor);
+extern int dhi_validate_int_gt(long value, long min);
+extern int dhi_validate_int_gte(long value, long min);
+extern int dhi_validate_int_lt(long value, long max);
+extern int dhi_validate_int_lte(long value, long max);
+extern int dhi_validate_int_positive(long value);
+extern int dhi_validate_int_non_negative(long value);
+extern int dhi_validate_int_negative(long value);
+extern int dhi_validate_int_non_positive(long value);
+extern int dhi_validate_int_multiple_of(long value, long divisor);
 
 // Float validators
-extern int satya_validate_float_gt(double value, double min);
-extern int satya_validate_float_finite(double value);
+extern int dhi_validate_float_gt(double value, double min);
+extern int dhi_validate_float_finite(double value);
 ```
 
 ## 🎯 Python API (Coming Soon)
@@ -1442,7 +1442,7 @@ All while being **completely general** and **production-ready**! 🚀
 - `src/c_api.zig` - C API exports
 - `dhi/_native.c` - Python C extension (to be updated)
 - `dhi/batch.py` - Python wrapper (to be updated)
-# Contributing to satya-zig
+# Contributing to dhi
 
 Thanks for your interest in contributing! This document provides guidelines and information for contributors.
 
@@ -1455,8 +1455,8 @@ Thanks for your interest in contributing! This document provides guidelines and 
 
 2. **Clone the repository**
    ```bash
-   git clone https://github.com/yourusername/satya-zig.git
-   cd satya-zig
+   git clone https://github.com/yourusername/dhi.git
+   cd dhi
    ```
 
 3. **Run tests**
@@ -1472,7 +1472,7 @@ Thanks for your interest in contributing! This document provides guidelines and 
 ## Project Structure
 
 ```
-satya-zig/
+dhi/
 ├── src/
 │   ├── validator.zig        # Core validation primitives
 │   ├── combinators.zig      # Combinator patterns (Optional, OneOf, etc.)
@@ -1506,7 +1506,7 @@ Example validator structure:
 
 ```zig
 /// MyValidator validates X with constraints Y.
-/// Inspired by satya's Field(constraint=value) pattern.
+/// Validates fields with constraint=value pattern.
 pub const MyValidator = struct {
     const Self = @This();
     value: T,
@@ -1561,7 +1561,7 @@ test "BoundedInt - at boundaries" { ... }
 
 ```zig
 /// BoundedInt creates a validated integer type with compile-time bounds.
-/// Inspired by satya's Field(ge=min, le=max) pattern.
+/// Validates integers with ge=min, le=max pattern.
 ///
 /// Example:
 ///   const Age = BoundedInt(u8, 0, 130);
@@ -2401,7 +2401,7 @@ Mac Studio shows excellent thermal performance:
 
 ```bash
 # Always use the project's .venv
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 source ../.venv/bin/activate
 python benchmark_native.py
 ```
@@ -2566,7 +2566,7 @@ See `BENCHMARK_ANALYSIS.md` for detailed explanation.
 ### 1. Update Your Benchmarks
 
 ```bash
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 ./run_benchmark_venv.sh
 ```
 
@@ -2827,7 +2827,7 @@ results = validate_batch(users, schema)
 
 1. **Add C API function** in `src/c_api.zig`:
    ```zig
-   export fn satya_validate_batch(
+   export fn dhi_validate_batch(
        data_ptr: [*]const u8,
        data_len: usize,
        schema_ptr: [*]const SchemaField,
@@ -2885,7 +2885,7 @@ results = UserSchema.validate_json_array(json_bytes)
 
 2. **Expose via C API**:
    ```zig
-   export fn satya_validate_json_array(
+   export fn dhi_validate_json_array(
        json_ptr: [*]const u8,
        json_len: usize,
        schema_ptr: [*]const SchemaField,
@@ -3176,7 +3176,7 @@ This will make dhi a complete, high-performance validation library suitable for 
 
 ```bash
 # Go to GitHub repo settings
-https://github.com/justrach/satya-zig/settings/secrets/actions
+https://github.com/justrach/dhi/settings/secrets/actions
 
 # Click "New repository secret"
 # Name: PYPI_API_TOKEN
@@ -3186,7 +3186,7 @@ https://github.com/justrach/satya-zig/settings/secrets/actions
 ### 2. Verify Git Status
 
 ```bash
-cd /Users/rachpradhan/satya-zig
+cd /Users/rachpradhan/dhi
 git status  # Make sure you're on main branch
 git remote -v  # Verify origin is correct
 ```
@@ -3208,7 +3208,7 @@ This will:
 ### Option B: Manual
 
 ```bash
-cd /Users/rachpradhan/satya-zig
+cd /Users/rachpradhan/dhi
 
 # Commit
 git add -A
@@ -3226,7 +3226,7 @@ git push origin v1.0.11
 
 After pushing the tag:
 
-1. **Watch GitHub Actions**: https://github.com/justrach/satya-zig/actions
+1. **Watch GitHub Actions**: https://github.com/justrach/dhi/actions
 2. **Check build progress** (takes ~10-15 minutes):
    - Build Zig library (macOS, Linux, Windows)
    - Build Python wheels (3.8-3.13 for each platform)
@@ -3322,8 +3322,8 @@ Once verified:
 ### 📦 Installation
 
 ```bash
-git clone https://github.com/justrach/satya-zig.git
-cd satya-zig
+git clone https://github.com/justrach/dhi.git
+cd dhi
 zig build test
 ```
 
@@ -3350,10 +3350,10 @@ See [TODO.md](TODO.md) for the roadmap, including:
 
 ```zig
 const std = @import("std");
-const satya = @import("satya");
+const dhi = @import("dhi");
 
-const Age = satya.BoundedInt(u8, 18, 90);
-const Email = satya.Email;
+const Age = dhi.BoundedInt(u8, 18, 90);
+const Email = dhi.Email;
 
 const User = struct {
     name: []const u8,
@@ -3363,7 +3363,7 @@ const User = struct {
 
 // Validate JSON in one step
 const json = "{\"name\":\"Alice\",\"email\":\"alice@example.com\",\"age\":25}";
-const user = try satya.parseAndValidate(User, json, allocator);
+const user = try dhi.parseAndValidate(User, json, allocator);
 ```
 
 ### 🙏 Acknowledgments
@@ -3379,7 +3379,7 @@ MIT License - See [LICENSE](LICENSE) for details
 
 ---
 
-**Repository**: https://github.com/justrach/satya-zig  
+**Repository**: https://github.com/justrach/dhi  
 **Author**: [@justrach](https://github.com/justrach)  
 **Zig Version**: 0.15.1+
 # Satya Validation Patterns - Reference for Zig Implementation
@@ -3683,7 +3683,7 @@ pub fn parseAndValidate(comptime T: type, json: []const u8) !T {
 #### Python Wrapper (High Priority)
 - [ ] Create Python bindings using `ctypes` or `cffi`
 - [ ] Expose core validation functions to Python
-- [ ] Package as `satya-zig-py` on PyPI
+- [ ] Package as `dhi-py` on PyPI
 - [ ] Write Python examples showing interop
 - [ ] Benchmark against Pydantic for performance comparison
 - [ ] Consider using `zig build-lib -dynamic` for shared library
@@ -3695,7 +3695,7 @@ zig build-lib src/root.zig -dynamic -OReleaseFast
 
 # Python wrapper example
 import ctypes
-satya = ctypes.CDLL('./libsatya.so')
+dhi_lib = ctypes.CDLL('./libdhi.so')
 # Define function signatures and call from Python
 ```
 
@@ -3703,7 +3703,7 @@ satya = ctypes.CDLL('./libsatya.so')
 - [ ] Create WASM build target for browser/Node.js
 - [ ] Use `zig build-lib -target wasm32-freestanding`
 - [ ] Write TypeScript type definitions
-- [ ] Package as `@satya/zig` on npm
+- [ ] Package as `@dhi/zig` on npm
 - [ ] Create Zod-like API for TypeScript users
 - [ ] Add examples for Next.js/React integration
 
@@ -3713,14 +3713,14 @@ satya = ctypes.CDLL('./libsatya.so')
 zig build-lib src/root.zig -target wasm32-freestanding -dynamic -rdynamic
 
 # TypeScript wrapper
-import { instantiate } from './satya.wasm';
+import { instantiate } from './dhi.wasm';
 export const validate = (data: unknown) => { /* ... */ };
 ```
 
 #### Rust FFI (Low Priority)
 - [ ] Create C-compatible API layer
 - [ ] Generate Rust bindings with `bindgen`
-- [ ] Publish as `satya-zig` crate on crates.io
+- [ ] Publish as `dhi` crate on crates.io
 
 ### Core Library Improvements
 
@@ -3799,17 +3799,17 @@ Create `src/python_ext.c`:
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-// Link against libsatya.dylib
-extern int satya_validate_int(long value, long min, long max);
-extern int satya_validate_string_length(const char* str, size_t min_len, size_t max_len);
-extern int satya_validate_email(const char* str);
+// Link against libdhi.dylib
+extern int dhi_validate_int(long value, long min, long max);
+extern int dhi_validate_string_length(const char* str, size_t min_len, size_t max_len);
+extern int dhi_validate_email(const char* str);
 
 static PyObject* py_validate_int(PyObject* self, PyObject* args) {
     long value, min, max;
     if (!PyArg_ParseTuple(args, "lll", &value, &min, &max))
         return NULL;
     
-    int result = satya_validate_int(value, min, max);
+    int result = dhi_validate_int(value, min, max);
     return PyBool_FromLong(result);
 }
 
@@ -3834,7 +3834,7 @@ PyMODINIT_FUNC PyInit__dhi_native(void) {
 **Build**:
 ```bash
 gcc -shared -fPIC -I/usr/include/python3.11 \
-    src/python_ext.c -L./zig-out/lib -lsatya \
+    src/python_ext.c -L./zig-out/lib -ldhi \
     -o dhi/_dhi_native.so
 ```
 
@@ -3853,7 +3853,7 @@ Validate many items in one FFI call.
 
 Update `src/c_api.zig` (already done!):
 ```zig
-export fn satya_validate_users_batch(
+export fn dhi_validate_users_batch(
     ids: [*]const i64,
     names: [*]const [*:0]const u8,
     emails: [*]const [*:0]const u8,
@@ -3874,7 +3874,7 @@ def validate_batch(users: List[dict]) -> List[bool]:
     results = (ctypes.c_uint8 * len(users))()
     
     # Single FFI call!
-    _zig._lib.satya_validate_users_batch(ids, names, emails, ages, len(users), results)
+    _zig._lib.dhi_validate_users_batch(ids, names, emails, ages, len(users), results)
     return [bool(r) for r in results]
 ```
 
@@ -4202,7 +4202,7 @@ print(f'✅ dhi v1.0.0 installed! Valid: {count}/{len(users)}')
 ## 🔗 Links to Share
 
 - **PyPI**: https://pypi.org/project/dhi/
-- **GitHub**: https://github.com/justrach/satya-zig
+- **GitHub**: https://github.com/justrach/dhi
 - **Benchmarks**: 28M users/sec (see benchmark_batch.py)
 
 ## 🎉 Congratulations!
@@ -4228,8 +4228,8 @@ From 0 to 28M validations/sec in one session. 🚀
 
 ```bash
 # Clone and build locally
-git clone https://github.com/justrach/satya-zig.git
-cd satya-zig
+git clone https://github.com/justrach/dhi.git
+cd dhi
 zig build -Doptimize=ReleaseFast
 cd python-bindings
 pip install -e .
@@ -4287,7 +4287,7 @@ ls -lh dist/
 ### Step 1: Test Locally (Optional but Recommended)
 
 ```bash
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 
 # Test the wheel
 pip install dist/dhi-1.0.0-cp314-cp314-macosx_11_0_arm64.whl --force-reinstall
@@ -4321,7 +4321,7 @@ export TWINE_PASSWORD=pypi-YOUR_TOKEN_HERE
 ### Step 3: Upload to Test PyPI (RECOMMENDED FIRST!)
 
 ```bash
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 
 # Upload to test PyPI
 twine upload --repository testpypi dist/*
@@ -4336,7 +4336,7 @@ python -c "from dhi import _dhi_native; print('✅ Test PyPI installation works!
 ### Step 4: Upload to Production PyPI
 
 ```bash
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 
 # 🎉 THE BIG MOMENT! 🎉
 twine upload dist/*
@@ -4431,7 +4431,7 @@ results, count = _dhi_native.validate_batch_direct(users, specs)
 
 Built with Zig for maximum performance. MIT licensed.
 
-GitHub: https://github.com/justrach/satya-zig
+GitHub: https://github.com/justrach/dhi
 PyPI: https://pypi.org/project/dhi/
 
 Would love your feedback!
@@ -4468,7 +4468,7 @@ If people like it:
 **Ready to publish?**
 
 ```bash
-cd /Users/rachpradhan/satya-zig/python-bindings
+cd /Users/rachpradhan/dhi/python-bindings
 twine upload dist/*
 ```
 

--- a/benchmarks/benchmark.zig
+++ b/benchmarks/benchmark.zig
@@ -104,7 +104,7 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    std.debug.print("=== satya-zig Performance Benchmarks ===\n\n", .{});
+    std.debug.print("=== dhi Performance Benchmarks ===\n\n", .{});
 
     try benchmarkSingleValidation(allocator);
     try benchmarkBatchValidation(allocator);

--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
 
     // Creates a step for building the library
     const lib = b.addLibrary(.{
-        .name = "satya-zig",
+        .name = "dhi-zig",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/root.zig"),
             .target = target,
@@ -41,7 +41,7 @@ pub fn build(b: *std.Build) void {
 
     // Build shared library for Python bindings
     const c_lib = b.addLibrary(.{
-        .name = "satya",
+        .name = "dhi",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/c_api.zig"),
             .target = target,

--- a/examples/basic_usage.zig
+++ b/examples/basic_usage.zig
@@ -179,7 +179,7 @@ pub fn main() !void {
         };
     }
 
-    // Example 5: ValidationResult pattern (satya-style)
+    // Example 5: ValidationResult pattern (dhi-style)
     std.debug.print("Example 5: ValidationResult pattern\n", .{});
     {
         // Create a result-style validator

--- a/examples/json_example.zig
+++ b/examples/json_example.zig
@@ -127,7 +127,7 @@ pub fn main() !void {
         };
     }
 
-    // Example 7: Batch validation (satya's validate_batch pattern)
+    // Example 7: Batch validation (dhi's validate_batch pattern)
     std.debug.print("\nExample 7: Batch validation (multiple products)\n", .{});
     {
         const json = 

--- a/js-bindings/CHANGELOG.md
+++ b/js-bindings/CHANGELOG.md
@@ -46,4 +46,4 @@ Initial release with batch validation API.
 
 ---
 
-For full details, see [GitHub Releases](https://github.com/justrach/satya-zig/releases)
+For full details, see [GitHub Releases](https://github.com/justrach/dhi/releases)

--- a/js-bindings/NEXTJS.md
+++ b/js-bindings/NEXTJS.md
@@ -473,9 +473,9 @@ await init(); // One-time cost
 
 ## Support
 
-- **GitHub**: https://github.com/justrach/satya-zig
+- **GitHub**: https://github.com/justrach/dhi
 - **npm**: https://www.npmjs.com/package/dhi
-- **Issues**: https://github.com/justrach/satya-zig/issues
+- **Issues**: https://github.com/justrach/dhi/issues
 
 ## License
 

--- a/js-bindings/docs/ADDING_TO_OFFICIAL_BENCHMARKS.md
+++ b/js-bindings/docs/ADDING_TO_OFFICIAL_BENCHMARKS.md
@@ -166,8 +166,8 @@ dhi is a WASM-powered validation library that's 4.86x faster than Zod.
 
 ### Links
 - npm: https://www.npmjs.com/package/dhi
-- GitHub: https://github.com/justrach/satya-zig
-- Docs: https://github.com/justrach/satya-zig/blob/main/js-bindings/README.md
+- GitHub: https://github.com/justrach/dhi
+- Docs: https://github.com/justrach/dhi/blob/main/js-bindings/README.md
 
 ### Features
 - Drop-in Zod replacement

--- a/js-bindings/docs/PUBLISHING.md
+++ b/js-bindings/docs/PUBLISHING.md
@@ -38,7 +38,7 @@ cd test-dhi
 npm init -y
 
 # Install from local directory
-npm install /Users/rachpradhan/satya-zig/js-bindings
+npm install /Users/rachpradhan/dhi/js-bindings
 
 # Test it works
 cat > test.ts << 'EOF'
@@ -68,7 +68,7 @@ Enter your npm credentials.
 ### Option 1: Manual Publish (Recommended for First Time)
 
 ```bash
-cd /Users/rachpradhan/satya-zig/js-bindings
+cd /Users/rachpradhan/dhi/js-bindings
 
 # Final check
 npm pack --dry-run
@@ -91,7 +91,7 @@ npm publish --access public
    # Select "Automation" type
    ```
 
-   - Go to: https://github.com/justrach/satya-zig/settings/secrets/actions
+   - Go to: https://github.com/justrach/dhi/settings/secrets/actions
    - Click "New repository secret"
    - Name: `NPM_TOKEN`
    - Value: (paste your npm token)
@@ -105,7 +105,7 @@ npm publish --access public
    ```
 
    Option B: Manual trigger
-   - Go to: https://github.com/justrach/satya-zig/actions/workflows/publish-npm.yml
+   - Go to: https://github.com/justrach/dhi/actions/workflows/publish-npm.yml
    - Click "Run workflow"
    - Enter version: `0.3.0`
    - Click "Run workflow"
@@ -146,7 +146,7 @@ The fastest TypeScript validation library:
 
 npm install dhi
 
-https://github.com/justrach/satya-zig
+https://github.com/justrach/dhi
 ```
 
 ## Troubleshooting

--- a/js-bindings/examples/ai-sdk-tools/README.md
+++ b/js-bindings/examples/ai-sdk-tools/README.md
@@ -148,6 +148,6 @@ const result = await generateText({
 
 ## Learn More
 
-- [dhi Documentation](https://github.com/justrach/satya-zig)
+- [dhi Documentation](https://github.com/justrach/dhi)
 - [Vercel AI SDK Documentation](https://sdk.vercel.ai/docs)
 - [dhi Benchmarks](../../benchmarks/)

--- a/js-bindings/examples/durable-agent/README.md
+++ b/js-bindings/examples/durable-agent/README.md
@@ -221,5 +221,5 @@ This pattern is ideal for:
 ## Learn More
 
 - [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/)
-- [dhi Documentation](https://github.com/justrach/satya-zig)
+- [dhi Documentation](https://github.com/justrach/dhi)
 - [Vercel AI SDK](https://sdk.vercel.ai/docs)

--- a/js-bindings/examples/frontend/app/page.tsx
+++ b/js-bindings/examples/frontend/app/page.tsx
@@ -174,7 +174,7 @@ export default function Home() {
 
         <div className="mt-6 text-center text-sm text-gray-500 dark:text-gray-400">
           <a 
-            href="https://github.com/justrach/satya-zig"
+            href="https://github.com/justrach/dhi"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-blue-600 dark:hover:text-blue-400 transition underline"

--- a/python-bindings/README.md
+++ b/python-bindings/README.md
@@ -19,7 +19,7 @@ field_specs = {
 }
 
 results, valid_count = _dhi_native.validate_batch_direct(users, field_specs)
-# 28M users/sec! 🔥
+# 24M users/sec! 🔥
 ```
 
 ## ✨ Features

--- a/python-bindings/dhi/_native.c
+++ b/python-bindings/dhi/_native.c
@@ -1,6 +1,6 @@
 /*
  * Native CPython extension for dhi
- * Links against libsatya.dylib (Zig backend)
+ * Links against libdhi.dylib (Zig backend)
  */
 
 #define PY_SSIZE_T_CLEAN
@@ -13,7 +13,7 @@
 // =============================================================================
 
 // Inline email validator - avoids Zig FFI call for simple email format checks
-// This is the same logic as Zig's satya_validate_email but runs in C
+// This is the same logic as Zig's dhi_validate_email but runs in C
 static inline int inline_validate_email(const char* str) {
     if (!str || !*str) return 0;
 
@@ -32,66 +32,66 @@ static inline int inline_validate_email(const char* str) {
     return 1;
 }
 
-// External Zig functions from libsatya - COMPREHENSIVE VALIDATORS
+// External Zig functions from libdhi - COMPREHENSIVE VALIDATORS
 // Basic validators
-extern int satya_validate_int(long value, long min, long max);
-extern int satya_validate_string_length(const char* str, size_t min_len, size_t max_len);
-extern int satya_validate_email(const char* str);
+extern int dhi_validate_int(long value, long min, long max);
+extern int dhi_validate_string_length(const char* str, size_t min_len, size_t max_len);
+extern int dhi_validate_email(const char* str);
 
 // String validators (Zod-style)
-extern int satya_validate_url(const char* str);
-extern int satya_validate_uuid(const char* str);
-extern int satya_validate_ipv4(const char* str);
-extern int satya_validate_base64(const char* str);
-extern int satya_validate_iso_date(const char* str);
-extern int satya_validate_iso_datetime(const char* str);
-extern int satya_validate_contains(const char* str, const char* substring);
-extern int satya_validate_starts_with(const char* str, const char* prefix);
-extern int satya_validate_ends_with(const char* str, const char* suffix);
+extern int dhi_validate_url(const char* str);
+extern int dhi_validate_uuid(const char* str);
+extern int dhi_validate_ipv4(const char* str);
+extern int dhi_validate_base64(const char* str);
+extern int dhi_validate_iso_date(const char* str);
+extern int dhi_validate_iso_datetime(const char* str);
+extern int dhi_validate_contains(const char* str, const char* substring);
+extern int dhi_validate_starts_with(const char* str, const char* prefix);
+extern int dhi_validate_ends_with(const char* str, const char* suffix);
 
 // Number validators (Pydantic-style)
-extern int satya_validate_int_gt(long value, long min);
-extern int satya_validate_int_gte(long value, long min);
-extern int satya_validate_int_lt(long value, long max);
-extern int satya_validate_int_lte(long value, long max);
-extern int satya_validate_int_positive(long value);
-extern int satya_validate_int_non_negative(long value);
-extern int satya_validate_int_negative(long value);
-extern int satya_validate_int_non_positive(long value);
-extern int satya_validate_int_multiple_of(long value, long divisor);
+extern int dhi_validate_int_gt(long value, long min);
+extern int dhi_validate_int_gte(long value, long min);
+extern int dhi_validate_int_lt(long value, long max);
+extern int dhi_validate_int_lte(long value, long max);
+extern int dhi_validate_int_positive(long value);
+extern int dhi_validate_int_non_negative(long value);
+extern int dhi_validate_int_negative(long value);
+extern int dhi_validate_int_non_positive(long value);
+extern int dhi_validate_int_multiple_of(long value, long divisor);
 
 // Float validators
-extern int satya_validate_float_gt(double value, double min);
-extern int satya_validate_float_gte(double value, double min);
-extern int satya_validate_float_lt(double value, double max);
-extern int satya_validate_float_lte(double value, double max);
-extern int satya_validate_float_finite(double value);
+extern int dhi_validate_float_gt(double value, double min);
+extern int dhi_validate_float_gte(double value, double min);
+extern int dhi_validate_float_lt(double value, double max);
+extern int dhi_validate_float_lte(double value, double max);
+extern int dhi_validate_float_finite(double value);
 
 // IPv6 validator
-extern int satya_validate_ipv6(const char* str);
+extern int dhi_validate_ipv6(const char* str);
 
 // =============================================================================
 // SIMD JSON PARSING FUNCTIONS FROM ZIG
 // =============================================================================
-extern size_t satya_skip_whitespace(const char* json, size_t len, size_t start);
-extern int satya_extract_json_string(
+extern size_t dhi_skip_whitespace(const char* json, size_t len, size_t start);
+extern int dhi_extract_json_string(
     const char* json, size_t len, size_t start,
     const char** out_str_ptr, size_t* out_str_len,
     int* out_has_escapes, size_t* out_end
 );
-extern int satya_parse_json_int(
+extern int dhi_parse_json_int(
     const char* json, size_t len, size_t start,
     long* out_value, size_t* out_end
 );
-extern int satya_parse_json_float(
+extern int dhi_parse_json_float(
     const char* json, size_t len, size_t start,
     double* out_value, size_t* out_end
 );
-extern int satya_skip_json_value(
+extern int dhi_skip_json_value(
     const char* json, size_t len, size_t start,
     size_t* out_end
 );
-extern unsigned long long satya_hash_field_name(const char* name, size_t len);
+extern unsigned long long dhi_hash_field_name(const char* name, size_t len);
 
 // =============================================================================
 // FNV-1a HASH - Fast hash for JSON field matching (computed at compile time)
@@ -113,7 +113,7 @@ static PyObject* py_validate_int(PyObject* self, PyObject* args) {
         return NULL;
     }
     
-    int result = satya_validate_int(value, min, max);
+    int result = dhi_validate_int(value, min, max);
     return PyBool_FromLong(result);
 }
 
@@ -126,7 +126,7 @@ static PyObject* py_validate_string_length(PyObject* self, PyObject* args) {
         return NULL;
     }
     
-    int result = satya_validate_string_length(str, (size_t)min_len, (size_t)max_len);
+    int result = dhi_validate_string_length(str, (size_t)min_len, (size_t)max_len);
     return PyBool_FromLong(result);
 }
 
@@ -138,7 +138,7 @@ static PyObject* py_validate_email(PyObject* self, PyObject* args) {
         return NULL;
     }
     
-    int result = satya_validate_email(str);
+    int result = dhi_validate_email(str);
     return PyBool_FromLong(result);
 }
 
@@ -307,82 +307,82 @@ static PyObject* py_validate_batch_direct(PyObject* self, PyObject* args) {
             switch (field_specs[f].validator_type) {
                 case VAL_INT: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int(value, field_specs[f].param1, field_specs[f].param2);
+                    is_valid = dhi_validate_int(value, field_specs[f].param1, field_specs[f].param2);
                     break;
                 }
                 case VAL_INT_GT: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_gt(value, field_specs[f].param1);
+                    is_valid = dhi_validate_int_gt(value, field_specs[f].param1);
                     break;
                 }
                 case VAL_INT_GTE: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_gte(value, field_specs[f].param1);
+                    is_valid = dhi_validate_int_gte(value, field_specs[f].param1);
                     break;
                 }
                 case VAL_INT_LT: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_lt(value, field_specs[f].param1);
+                    is_valid = dhi_validate_int_lt(value, field_specs[f].param1);
                     break;
                 }
                 case VAL_INT_LTE: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_lte(value, field_specs[f].param1);
+                    is_valid = dhi_validate_int_lte(value, field_specs[f].param1);
                     break;
                 }
                 case VAL_INT_POSITIVE: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_positive(value);
+                    is_valid = dhi_validate_int_positive(value);
                     break;
                 }
                 case VAL_INT_NON_NEGATIVE: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_non_negative(value);
+                    is_valid = dhi_validate_int_non_negative(value);
                     break;
                 }
                 case VAL_INT_MULTIPLE_OF: {
                     long value = PyLong_AsLong(field_value);
-                    is_valid = satya_validate_int_multiple_of(value, field_specs[f].param1);
+                    is_valid = dhi_validate_int_multiple_of(value, field_specs[f].param1);
                     break;
                 }
                 case VAL_STRING: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_string_length(value, (size_t)field_specs[f].param1, (size_t)field_specs[f].param2);
+                    is_valid = dhi_validate_string_length(value, (size_t)field_specs[f].param1, (size_t)field_specs[f].param2);
                     break;
                 }
                 case VAL_EMAIL: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_email(value);
+                    is_valid = dhi_validate_email(value);
                     break;
                 }
                 case VAL_URL: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_url(value);
+                    is_valid = dhi_validate_url(value);
                     break;
                 }
                 case VAL_UUID: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_uuid(value);
+                    is_valid = dhi_validate_uuid(value);
                     break;
                 }
                 case VAL_IPV4: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_ipv4(value);
+                    is_valid = dhi_validate_ipv4(value);
                     break;
                 }
                 case VAL_BASE64: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_base64(value);
+                    is_valid = dhi_validate_base64(value);
                     break;
                 }
                 case VAL_ISO_DATE: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_iso_date(value);
+                    is_valid = dhi_validate_iso_date(value);
                     break;
                 }
                 case VAL_ISO_DATETIME: {
                     const char* value = PyUnicode_AsUTF8(field_value);
-                    is_valid = satya_validate_iso_datetime(value);
+                    is_valid = dhi_validate_iso_datetime(value);
                     break;
                 }
                 case VAL_UNKNOWN:
@@ -844,13 +844,13 @@ static PyObject* py_init_model_compiled(PyObject* self_unused, PyObject* args) {
             const char *fmt_name = "unknown";
             switch (fs->format_code) {
                 case 1: valid = inline_validate_email(str_val); fmt_name = "email"; break;  // INLINED
-                case 2: valid = satya_validate_url(str_val); fmt_name = "URL"; break;
-                case 3: valid = satya_validate_uuid(str_val); fmt_name = "UUID"; break;
-                case 4: valid = satya_validate_ipv4(str_val); fmt_name = "IPv4"; break;
-                case 5: valid = satya_validate_ipv6(str_val); fmt_name = "IPv6"; break;
-                case 6: valid = satya_validate_base64(str_val); fmt_name = "base64"; break;
-                case 7: valid = satya_validate_iso_date(str_val); fmt_name = "ISO date"; break;
-                case 8: valid = satya_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
+                case 2: valid = dhi_validate_url(str_val); fmt_name = "URL"; break;
+                case 3: valid = dhi_validate_uuid(str_val); fmt_name = "UUID"; break;
+                case 4: valid = dhi_validate_ipv4(str_val); fmt_name = "IPv4"; break;
+                case 5: valid = dhi_validate_ipv6(str_val); fmt_name = "IPv6"; break;
+                case 6: valid = dhi_validate_base64(str_val); fmt_name = "base64"; break;
+                case 7: valid = dhi_validate_iso_date(str_val); fmt_name = "ISO date"; break;
+                case 8: valid = dhi_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
             }
             if (!valid) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
@@ -1020,7 +1020,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         long val = PyLong_AsLong(result);
         if (gt_obj != Py_None) {
             long gt_val = as_long_coerce(gt_obj);
-            if (!satya_validate_int_gt(val, gt_val)) {
+            if (!dhi_validate_int_gt(val, gt_val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be > %ld, got %ld", field_name, gt_val, val);
@@ -1028,7 +1028,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (ge_obj != Py_None) {
             long ge_val = as_long_coerce(ge_obj);
-            if (!satya_validate_int_gte(val, ge_val)) {
+            if (!dhi_validate_int_gte(val, ge_val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be >= %ld, got %ld", field_name, ge_val, val);
@@ -1036,7 +1036,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (lt_obj != Py_None) {
             long lt_val = as_long_coerce(lt_obj);
-            if (!satya_validate_int_lt(val, lt_val)) {
+            if (!dhi_validate_int_lt(val, lt_val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be < %ld, got %ld", field_name, lt_val, val);
@@ -1044,7 +1044,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (le_obj != Py_None) {
             long le_val = as_long_coerce(le_obj);
-            if (!satya_validate_int_lte(val, le_val)) {
+            if (!dhi_validate_int_lte(val, le_val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be <= %ld, got %ld", field_name, le_val, val);
@@ -1052,7 +1052,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (mul_obj != Py_None) {
             long mul_val = as_long_coerce(mul_obj);
-            if (!satya_validate_int_multiple_of(val, mul_val)) {
+            if (!dhi_validate_int_multiple_of(val, mul_val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be a multiple of %ld, got %ld", field_name, mul_val, val);
@@ -1061,7 +1061,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
     } else if (PyFloat_Check(result)) {
         double val = PyFloat_AsDouble(result);
         if (!allow_inf_nan) {
-            if (!satya_validate_float_finite(val)) {
+            if (!dhi_validate_float_finite(val)) {
                 Py_DECREF(result);
                 return PyErr_Format(PyExc_ValueError,
                     "%s: Value must be finite", field_name);
@@ -1069,7 +1069,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (gt_obj != Py_None) {
             double gt_val = as_double_coerce(gt_obj);
-            if (!satya_validate_float_gt(val, gt_val)) {
+            if (!dhi_validate_float_gt(val, gt_val)) {
                 char buf[128];
                 snprintf(buf, sizeof(buf), "%s: Value must be > %g, got %g", field_name, gt_val, val);
                 Py_DECREF(result);
@@ -1079,7 +1079,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (ge_obj != Py_None) {
             double ge_val = as_double_coerce(ge_obj);
-            if (!satya_validate_float_gte(val, ge_val)) {
+            if (!dhi_validate_float_gte(val, ge_val)) {
                 char buf[128];
                 snprintf(buf, sizeof(buf), "%s: Value must be >= %g, got %g", field_name, ge_val, val);
                 Py_DECREF(result);
@@ -1089,7 +1089,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (lt_obj != Py_None) {
             double lt_val = as_double_coerce(lt_obj);
-            if (!satya_validate_float_lt(val, lt_val)) {
+            if (!dhi_validate_float_lt(val, lt_val)) {
                 char buf[128];
                 snprintf(buf, sizeof(buf), "%s: Value must be < %g, got %g", field_name, lt_val, val);
                 Py_DECREF(result);
@@ -1099,7 +1099,7 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
         }
         if (le_obj != Py_None) {
             double le_val = as_double_coerce(le_obj);
-            if (!satya_validate_float_lte(val, le_val)) {
+            if (!dhi_validate_float_lte(val, le_val)) {
                 char buf[128];
                 snprintf(buf, sizeof(buf), "%s: Value must be <= %g, got %g", field_name, le_val, val);
                 Py_DECREF(result);
@@ -1154,13 +1154,13 @@ static PyObject* validate_field_core(PyObject *value, const char *field_name, Py
 
         switch (format_code) {
             case 1: valid = inline_validate_email(str_val); fmt_name = "email"; break;  // INLINED
-            case 2: valid = satya_validate_url(str_val); fmt_name = "URL"; break;
-            case 3: valid = satya_validate_uuid(str_val); fmt_name = "UUID"; break;
-            case 4: valid = satya_validate_ipv4(str_val); fmt_name = "IPv4"; break;
-            case 5: valid = satya_validate_ipv6(str_val); fmt_name = "IPv6"; break;
-            case 6: valid = satya_validate_base64(str_val); fmt_name = "base64"; break;
-            case 7: valid = satya_validate_iso_date(str_val); fmt_name = "ISO date"; break;
-            case 8: valid = satya_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
+            case 2: valid = dhi_validate_url(str_val); fmt_name = "URL"; break;
+            case 3: valid = dhi_validate_uuid(str_val); fmt_name = "UUID"; break;
+            case 4: valid = dhi_validate_ipv4(str_val); fmt_name = "IPv4"; break;
+            case 5: valid = dhi_validate_ipv6(str_val); fmt_name = "IPv6"; break;
+            case 6: valid = dhi_validate_base64(str_val); fmt_name = "base64"; break;
+            case 7: valid = dhi_validate_iso_date(str_val); fmt_name = "ISO date"; break;
+            case 8: valid = dhi_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
         }
 
         if (!valid) {
@@ -1751,7 +1751,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
         int validation_failed = 0;
         if (PyLong_Check(result) && !PyBool_Check(result)) {
             long val = PyLong_AsLong(result);
-            // INLINED: val > gt_long (was satya_validate_int_gt)
+            // INLINED: val > gt_long (was dhi_validate_int_gt)
             if (fs->has_gt && val <= fs->gt_long) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1759,7 +1759,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
                 PyObject *err = Py_BuildValue("(OO)", fs->name_obj, msg); Py_DECREF(msg);
                 PyList_Append(errors, err); Py_DECREF(err); Py_DECREF(result); continue;
             }
-            // INLINED: val >= ge_long (was satya_validate_int_gte)
+            // INLINED: val >= ge_long (was dhi_validate_int_gte)
             if (fs->has_ge && val < fs->ge_long) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1767,7 +1767,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
                 PyObject *err = Py_BuildValue("(OO)", fs->name_obj, msg); Py_DECREF(msg);
                 PyList_Append(errors, err); Py_DECREF(err); Py_DECREF(result); continue;
             }
-            // INLINED: val < lt_long (was satya_validate_int_lt)
+            // INLINED: val < lt_long (was dhi_validate_int_lt)
             if (fs->has_lt && val >= fs->lt_long) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1775,7 +1775,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
                 PyObject *err = Py_BuildValue("(OO)", fs->name_obj, msg); Py_DECREF(msg);
                 PyList_Append(errors, err); Py_DECREF(err); Py_DECREF(result); continue;
             }
-            // INLINED: val <= le_long (was satya_validate_int_lte)
+            // INLINED: val <= le_long (was dhi_validate_int_lte)
             if (fs->has_le && val > fs->le_long) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1783,7 +1783,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
                 PyObject *err = Py_BuildValue("(OO)", fs->name_obj, msg); Py_DECREF(msg);
                 PyList_Append(errors, err); Py_DECREF(err); Py_DECREF(result); continue;
             }
-            // INLINED: val % mul_long == 0 (was satya_validate_int_multiple_of)
+            // INLINED: val % mul_long == 0 (was dhi_validate_int_multiple_of)
             if (fs->has_mul && (val % fs->mul_long) != 0) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1793,7 +1793,7 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
             }
         } else if (PyFloat_Check(result)) {
             double val = PyFloat_AsDouble(result);
-            // INLINED: isfinite check (was satya_validate_float_finite)
+            // INLINED: isfinite check (was dhi_validate_float_finite)
             if (!fs->allow_inf_nan && !isfinite(val)) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
                 if (!errors) { errors = PyList_New(0); }
@@ -1855,13 +1855,13 @@ static PyObject* py_init_model_full(PyObject* self_unused, PyObject *const *args
             const char *fmt_name = "unknown";
             switch (fs->format_code) {
                 case 1: valid = inline_validate_email(str_val); fmt_name = "email"; break;  // INLINED
-                case 2: valid = satya_validate_url(str_val); fmt_name = "URL"; break;
-                case 3: valid = satya_validate_uuid(str_val); fmt_name = "UUID"; break;
-                case 4: valid = satya_validate_ipv4(str_val); fmt_name = "IPv4"; break;
-                case 5: valid = satya_validate_ipv6(str_val); fmt_name = "IPv6"; break;
-                case 6: valid = satya_validate_base64(str_val); fmt_name = "base64"; break;
-                case 7: valid = satya_validate_iso_date(str_val); fmt_name = "ISO date"; break;
-                case 8: valid = satya_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
+                case 2: valid = dhi_validate_url(str_val); fmt_name = "URL"; break;
+                case 3: valid = dhi_validate_uuid(str_val); fmt_name = "UUID"; break;
+                case 4: valid = dhi_validate_ipv4(str_val); fmt_name = "IPv4"; break;
+                case 5: valid = dhi_validate_ipv6(str_val); fmt_name = "IPv6"; break;
+                case 6: valid = dhi_validate_base64(str_val); fmt_name = "base64"; break;
+                case 7: valid = dhi_validate_iso_date(str_val); fmt_name = "ISO date"; break;
+                case 8: valid = dhi_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
             }
             if (!valid) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
@@ -2483,13 +2483,13 @@ static int DhiStruct_init(DhiStructObject *self, PyObject *args, PyObject *kwarg
             const char *fmt_name = "unknown";
             switch (fs->format_code) {
                 case 1: valid = inline_validate_email(str_val); fmt_name = "email"; break;
-                case 2: valid = satya_validate_url(str_val); fmt_name = "URL"; break;
-                case 3: valid = satya_validate_uuid(str_val); fmt_name = "UUID"; break;
-                case 4: valid = satya_validate_ipv4(str_val); fmt_name = "IPv4"; break;
-                case 5: valid = satya_validate_ipv6(str_val); fmt_name = "IPv6"; break;
-                case 6: valid = satya_validate_base64(str_val); fmt_name = "base64"; break;
-                case 7: valid = satya_validate_iso_date(str_val); fmt_name = "ISO date"; break;
-                case 8: valid = satya_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
+                case 2: valid = dhi_validate_url(str_val); fmt_name = "URL"; break;
+                case 3: valid = dhi_validate_uuid(str_val); fmt_name = "UUID"; break;
+                case 4: valid = dhi_validate_ipv4(str_val); fmt_name = "IPv4"; break;
+                case 5: valid = dhi_validate_ipv6(str_val); fmt_name = "IPv6"; break;
+                case 6: valid = dhi_validate_base64(str_val); fmt_name = "base64"; break;
+                case 7: valid = dhi_validate_iso_date(str_val); fmt_name = "ISO date"; break;
+                case 8: valid = dhi_validate_iso_datetime(str_val); fmt_name = "ISO datetime"; break;
             }
             if (!valid) {
                 field_name = PyUnicode_AsUTF8(fs->name_obj);
@@ -2689,7 +2689,7 @@ static PyObject* py_init_struct_class(PyObject *self, PyObject *args) {
 
 // Skip whitespace using SIMD (via Zig)
 #define SKIP_WS_SIMD(json, pos, len) \
-    (pos) = satya_skip_whitespace((json), (len), (pos))
+    (pos) = dhi_skip_whitespace((json), (len), (pos))
 
 // Fallback for simple cases
 #define SKIP_WS(json, pos, len) \
@@ -2734,7 +2734,7 @@ static inline char* json_parse_string_simd(const char *json, size_t *pos, size_t
     int has_escapes;
     size_t simd_end;
 
-    int result = satya_extract_json_string(json, len, start, &str_ptr, &str_len, &has_escapes, &simd_end);
+    int result = dhi_extract_json_string(json, len, start, &str_ptr, &str_len, &has_escapes, &simd_end);
     if (result != 0) return NULL;
 
     *out_len = str_len;
@@ -2964,7 +2964,7 @@ static inline PyObject* json_parse_number_simd(const char *json, size_t *pos, si
             // Float - use Zig SIMD for accuracy
             double fval;
             size_t end;
-            int result = satya_parse_json_float(json, len, *pos, &fval, &end);
+            int result = dhi_parse_json_float(json, len, *pos, &fval, &end);
             if (result != 0) {
                 PyErr_SetString(PyExc_ValueError, "Invalid float");
                 return NULL;
@@ -2982,7 +2982,7 @@ static inline PyObject* json_parse_number_simd(const char *json, size_t *pos, si
         // Very large integer - fall back to Zig SIMD
         long int_val;
         size_t end;
-        int result = satya_parse_json_int(json, len, *pos, &int_val, &end);
+        int result = dhi_parse_json_int(json, len, *pos, &int_val, &end);
         if (result != 0) {
             PyErr_SetString(PyExc_ValueError, "Invalid integer");
             return NULL;
@@ -3073,7 +3073,7 @@ static int json_skip_value(const char *json, size_t *pos, size_t len) {
 // SIMD-accelerated skip value using Zig backend
 static int json_skip_value_simd(const char *json, size_t *pos, size_t len) {
     size_t end;
-    int result = satya_skip_json_value(json, len, *pos, &end);
+    int result = dhi_skip_json_value(json, len, *pos, &end);
     if (result != 0) return 0;
     *pos = end;
     return 1;

--- a/python-bindings/dhi/validator.py
+++ b/python-bindings/dhi/validator.py
@@ -143,7 +143,7 @@ class Email:
 
 # TODO: Load Zig shared library for native performance
 # This is a pure Python implementation for now
-# Future: Use ctypes to call into libsatya.so for 100x+ speedup
+# Future: Use ctypes to call into libdhi.so for 100x+ speedup
 
 class _ZigValidator:
     """Native Zig validator"""
@@ -157,26 +157,26 @@ class _ZigValidator:
         lib_path = Path(__file__).parent.parent.parent / "zig-out" / "lib"
         
         # Try different library names
-        for name in ["libsatya.dylib", "libsatya.so", "satya.dll"]:
+        for name in ["libdhi.dylib", "libdhi.so", "dhi.dll"]:
             full_path = lib_path / name
             if full_path.exists():
                 try:
                     self._lib = ctypes.CDLL(str(full_path))
                     
                     # Define function signatures
-                    self._lib.satya_validate_int.argtypes = [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64]
-                    self._lib.satya_validate_int.restype = ctypes.c_int32
+                    self._lib.dhi_validate_int.argtypes = [ctypes.c_int64, ctypes.c_int64, ctypes.c_int64]
+                    self._lib.dhi_validate_int.restype = ctypes.c_int32
                     
-                    self._lib.satya_validate_string_length.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.c_size_t]
-                    self._lib.satya_validate_string_length.restype = ctypes.c_int32
+                    self._lib.dhi_validate_string_length.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.c_size_t]
+                    self._lib.dhi_validate_string_length.restype = ctypes.c_int32
                     
-                    self._lib.satya_validate_email.argtypes = [ctypes.c_char_p]
-                    self._lib.satya_validate_email.restype = ctypes.c_int32
+                    self._lib.dhi_validate_email.argtypes = [ctypes.c_char_p]
+                    self._lib.dhi_validate_email.restype = ctypes.c_int32
                     
-                    self._lib.satya_version.argtypes = []
-                    self._lib.satya_version.restype = ctypes.c_char_p
+                    self._lib.dhi_version.argtypes = []
+                    self._lib.dhi_version.restype = ctypes.c_char_p
                     
-                    version = self._lib.satya_version().decode('utf-8')
+                    version = self._lib.dhi_version().decode('utf-8')
                     print(f"✅ Loaded native Zig library v{version}: {name}")
                     return
                 except Exception as e:
@@ -194,19 +194,19 @@ class _ZigValidator:
         """Validate integer using native Zig"""
         if not self.available:
             return min_val <= value <= max_val
-        return bool(self._lib.satya_validate_int(value, min_val, max_val))
+        return bool(self._lib.dhi_validate_int(value, min_val, max_val))
     
     def validate_string_length(self, value: str, min_len: int, max_len: int) -> bool:
         """Validate string length using native Zig"""
         if not self.available:
             return min_len <= len(value) <= max_len
-        return bool(self._lib.satya_validate_string_length(value.encode('utf-8'), min_len, max_len))
+        return bool(self._lib.dhi_validate_string_length(value.encode('utf-8'), min_len, max_len))
     
     def validate_email(self, value: str) -> bool:
         """Validate email using native Zig"""
         if not self.available:
             return "@" in value and "." in value.split("@")[-1]
-        return bool(self._lib.satya_validate_email(value.encode('utf-8')))
+        return bool(self._lib.dhi_validate_email(value.encode('utf-8')))
 
 
 # Global instance

--- a/python-bindings/setup.py
+++ b/python-bindings/setup.py
@@ -18,7 +18,7 @@ try:
         Path(__file__).parent / "dhi",  # Bundled in package
     ]
     
-    lib_name = 'satya'
+    lib_name = 'dhi'
     lib_file = None
     lib_dir = None
     

--- a/python-bindings/skills.md
+++ b/python-bindings/skills.md
@@ -463,7 +463,7 @@ python benchmark_vs_all.py
 
 | Library | Speed | Comparison |
 |---------|-------|------------|
-| dhi | 28M/sec | - |
+| dhi | 24M/sec | - |
 | satya (Rust) | 9M/sec | 3.0x slower |
 | msgspec (C) | 9M/sec | 3.1x slower |
 | Pydantic | 48K/sec | **520x slower** |

--- a/python-bindings/tests/test_regression_benchmarks.py
+++ b/python-bindings/tests/test_regression_benchmarks.py
@@ -1,0 +1,115 @@
+"""
+Regression tests for dhi validation performance.
+
+These tests ensure that core validation throughput doesn't regress
+below established baselines. The thresholds are set conservatively
+(50% of measured peaks) to avoid flaky failures on different hardware,
+while still catching major regressions.
+
+Baseline measured on Apple Silicon (M-series), March 2026:
+  - Batch validation: ~24M users/sec
+  - Single item validation: ~200K items/sec
+"""
+
+import time
+import pytest
+from dhi import _dhi_native
+
+
+def generate_users(n: int):
+    return [
+        {
+            "name": f"User{i}",
+            "email": f"user{i}@example.com",
+            "age": 20 + (i % 50),
+            "website": f"https://user{i}.com",
+        }
+        for i in range(n)
+    ]
+
+
+FIELD_SPECS = {
+    "name": ("string", 1, 100),
+    "email": ("email",),
+    "age": ("int_positive",),
+    "website": ("url",),
+}
+
+
+class TestBatchValidationRegression:
+    """Ensure batch validation throughput stays above baseline."""
+
+    def test_batch_10k_minimum_throughput(self):
+        """10K users should validate at >5M users/sec (conservative floor)."""
+        users = generate_users(10_000)
+
+        # Warmup
+        _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+
+        # Measure
+        start = time.perf_counter()
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        elapsed = time.perf_counter() - start
+
+        throughput = len(users) / elapsed
+        assert valid_count == 10_000, f"Expected all valid, got {valid_count}"
+        assert throughput > 5_000_000, (
+            f"Batch throughput regressed: {throughput:,.0f} users/sec "
+            f"(minimum: 5,000,000 users/sec)"
+        )
+
+    def test_batch_1k_minimum_throughput(self):
+        """1K users should validate at >2M users/sec."""
+        users = generate_users(1_000)
+
+        # Warmup
+        _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+
+        start = time.perf_counter()
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        elapsed = time.perf_counter() - start
+
+        throughput = len(users) / elapsed
+        assert valid_count == 1_000
+        assert throughput > 2_000_000, (
+            f"Batch throughput regressed: {throughput:,.0f} users/sec "
+            f"(minimum: 2,000,000 users/sec)"
+        )
+
+
+class TestValidationCorrectness:
+    """Ensure validators produce correct results after rename."""
+
+    def test_valid_user_passes(self):
+        users = [{"name": "Alice", "email": "alice@example.com", "age": 25, "website": "https://example.com"}]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 1
+
+    def test_invalid_email_fails(self):
+        users = [{"name": "Alice", "email": "not-an-email", "age": 25, "website": "https://example.com"}]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 0
+
+    def test_negative_age_fails(self):
+        users = [{"name": "Alice", "email": "alice@example.com", "age": -1, "website": "https://example.com"}]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 0
+
+    def test_empty_name_fails(self):
+        users = [{"name": "", "email": "alice@example.com", "age": 25, "website": "https://example.com"}]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 0
+
+    def test_invalid_url_fails(self):
+        users = [{"name": "Alice", "email": "alice@example.com", "age": 25, "website": "not-a-url"}]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 0
+
+    def test_batch_mixed_valid_invalid(self):
+        users = [
+            {"name": "Alice", "email": "alice@example.com", "age": 25, "website": "https://a.com"},
+            {"name": "", "email": "bad", "age": -1, "website": "nope"},
+            {"name": "Bob", "email": "bob@test.org", "age": 30, "website": "https://b.com"},
+        ]
+        results, valid_count = _dhi_native.validate_batch_direct(users, FIELD_SPECS)
+        assert valid_count == 2

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -10,14 +10,14 @@ const simd_json = @import("simd_json_parser.zig");
 pub const CFieldSpec = simd_json.CFieldSpec;
 
 // Export C-compatible functions
-export fn satya_validate_int(value: i64, min: i64, max: i64) i32 {
+export fn dhi_validate_int(value: i64, min: i64, max: i64) i32 {
     if (value < min or value > max) {
         return 0; // Invalid
     }
     return 1; // Valid
 }
 
-export fn satya_validate_string_length(str: [*:0]const u8, min_len: usize, max_len: usize)  i32 {
+export fn dhi_validate_string_length(str: [*:0]const u8, min_len: usize, max_len: usize)  i32 {
     const len = std.mem.len(str);
     if (len < min_len or len > max_len) {
         return 0; // Invalid
@@ -25,7 +25,7 @@ export fn satya_validate_string_length(str: [*:0]const u8, min_len: usize, max_l
     return 1; // Valid
 }
 
-export fn satya_validate_email(str: [*:0]const u8)  i32 {
+export fn dhi_validate_email(str: [*:0]const u8)  i32 {
     const email = std.mem.span(str);
     
     // Simple email validation
@@ -40,7 +40,7 @@ export fn satya_validate_email(str: [*:0]const u8)  i32 {
 }
 
 // Batch validation for performance
-export fn satya_validate_int_batch(
+export fn dhi_validate_int_batch(
     values: [*]const i64,
     count: usize,
     min: i64,
@@ -57,13 +57,13 @@ export fn satya_validate_int_batch(
 }
 
 // Version info
-export fn satya_version()  [*:0]const u8 {
+export fn dhi_version()  [*:0]const u8 {
     return "0.1.0";
 }
 
 // Batch user validation for performance
 // Returns number of valid users
-export fn satya_validate_users_batch(
+export fn dhi_validate_users_batch(
     ids: [*]const i64,
     names: [*]const [*:0]const u8,
     emails: [*]const [*:0]const u8,
@@ -114,138 +114,138 @@ export fn satya_validate_users_batch(
 }
 
 // Initialize/cleanup (for future use with allocators)
-export fn satya_init()  void {}
-export fn satya_cleanup()  void {}
+export fn dhi_init()  void {}
+export fn dhi_cleanup()  void {}
 
 // ============================================================================
 // COMPREHENSIVE VALIDATORS (Pydantic/Zod-style)
 // ============================================================================
 
 // String validators
-export fn satya_validate_url(str: [*:0]const u8) i32 {
+export fn dhi_validate_url(str: [*:0]const u8) i32 {
     const url = std.mem.span(str);
     return if (validators_comp.validateUrl(url)) 1 else 0;
 }
 
-export fn satya_validate_uuid(str: [*:0]const u8) i32 {
+export fn dhi_validate_uuid(str: [*:0]const u8) i32 {
     const uuid = std.mem.span(str);
     return if (validators_comp.validateUuid(uuid)) 1 else 0;
 }
 
-export fn satya_validate_ipv4(str: [*:0]const u8) i32 {
+export fn dhi_validate_ipv4(str: [*:0]const u8) i32 {
     const ip = std.mem.span(str);
     return if (validators_comp.validateIpv4(ip)) 1 else 0;
 }
 
-export fn satya_validate_base64(str: [*:0]const u8) i32 {
+export fn dhi_validate_base64(str: [*:0]const u8) i32 {
     const b64 = std.mem.span(str);
     return if (validators_comp.validateBase64(b64)) 1 else 0;
 }
 
-export fn satya_validate_iso_date(str: [*:0]const u8) i32 {
+export fn dhi_validate_iso_date(str: [*:0]const u8) i32 {
     const date = std.mem.span(str);
     return if (validators_comp.validateIsoDate(date)) 1 else 0;
 }
 
-export fn satya_validate_iso_datetime(str: [*:0]const u8) i32 {
+export fn dhi_validate_iso_datetime(str: [*:0]const u8) i32 {
     const datetime = std.mem.span(str);
     return if (validators_comp.validateIsoDatetime(datetime)) 1 else 0;
 }
 
-export fn satya_validate_contains(str: [*:0]const u8, substring: [*:0]const u8) i32 {
+export fn dhi_validate_contains(str: [*:0]const u8, substring: [*:0]const u8) i32 {
     const s = std.mem.span(str);
     const sub = std.mem.span(substring);
     return if (validators_comp.validateContains(s, sub)) 1 else 0;
 }
 
-export fn satya_validate_starts_with(str: [*:0]const u8, prefix: [*:0]const u8) i32 {
+export fn dhi_validate_starts_with(str: [*:0]const u8, prefix: [*:0]const u8) i32 {
     const s = std.mem.span(str);
     const pre = std.mem.span(prefix);
     return if (validators_comp.validateStartsWith(s, pre)) 1 else 0;
 }
 
-export fn satya_validate_ends_with(str: [*:0]const u8, suffix: [*:0]const u8) i32 {
+export fn dhi_validate_ends_with(str: [*:0]const u8, suffix: [*:0]const u8) i32 {
     const s = std.mem.span(str);
     const suf = std.mem.span(suffix);
     return if (validators_comp.validateEndsWith(s, suf)) 1 else 0;
 }
 
 // Number validators
-export fn satya_validate_int_gt(value: i64, min: i64) i32 {
+export fn dhi_validate_int_gt(value: i64, min: i64) i32 {
     return if (validators_comp.validateGt(i64, value, min)) 1 else 0;
 }
 
-export fn satya_validate_int_gte(value: i64, min: i64) i32 {
+export fn dhi_validate_int_gte(value: i64, min: i64) i32 {
     return if (validators_comp.validateGte(i64, value, min)) 1 else 0;
 }
 
-export fn satya_validate_int_lt(value: i64, max: i64) i32 {
+export fn dhi_validate_int_lt(value: i64, max: i64) i32 {
     return if (validators_comp.validateLt(i64, value, max)) 1 else 0;
 }
 
-export fn satya_validate_int_lte(value: i64, max: i64) i32 {
+export fn dhi_validate_int_lte(value: i64, max: i64) i32 {
     return if (validators_comp.validateLte(i64, value, max)) 1 else 0;
 }
 
-export fn satya_validate_int_positive(value: i64) i32 {
+export fn dhi_validate_int_positive(value: i64) i32 {
     return if (validators_comp.validatePositive(i64, value)) 1 else 0;
 }
 
-export fn satya_validate_int_non_negative(value: i64) i32 {
+export fn dhi_validate_int_non_negative(value: i64) i32 {
     return if (validators_comp.validateNonNegative(i64, value)) 1 else 0;
 }
 
-export fn satya_validate_int_negative(value: i64) i32 {
+export fn dhi_validate_int_negative(value: i64) i32 {
     return if (validators_comp.validateNegative(i64, value)) 1 else 0;
 }
 
-export fn satya_validate_int_non_positive(value: i64) i32 {
+export fn dhi_validate_int_non_positive(value: i64) i32 {
     return if (validators_comp.validateNonPositive(i64, value)) 1 else 0;
 }
 
-export fn satya_validate_int_multiple_of(value: i64, divisor: i64) i32 {
+export fn dhi_validate_int_multiple_of(value: i64, divisor: i64) i32 {
     return if (validators_comp.validateMultipleOf(i64, value, divisor)) 1 else 0;
 }
 
 // Float validators - full Pydantic numeric constraint parity
-export fn satya_validate_float_gt(value: f64, min: f64) i32 {
+export fn dhi_validate_float_gt(value: f64, min: f64) i32 {
     return if (validators_comp.validateGt(f64, value, min)) 1 else 0;
 }
 
-export fn satya_validate_float_gte(value: f64, min: f64) i32 {
+export fn dhi_validate_float_gte(value: f64, min: f64) i32 {
     return if (validators_comp.validateGte(f64, value, min)) 1 else 0;
 }
 
-export fn satya_validate_float_lt(value: f64, max: f64) i32 {
+export fn dhi_validate_float_lt(value: f64, max: f64) i32 {
     return if (validators_comp.validateLt(f64, value, max)) 1 else 0;
 }
 
-export fn satya_validate_float_lte(value: f64, max: f64) i32 {
+export fn dhi_validate_float_lte(value: f64, max: f64) i32 {
     return if (validators_comp.validateLte(f64, value, max)) 1 else 0;
 }
 
-export fn satya_validate_float_positive(value: f64) i32 {
+export fn dhi_validate_float_positive(value: f64) i32 {
     return if (validators_comp.validatePositive(f64, value)) 1 else 0;
 }
 
-export fn satya_validate_float_negative(value: f64) i32 {
+export fn dhi_validate_float_negative(value: f64) i32 {
     return if (validators_comp.validateNegative(f64, value)) 1 else 0;
 }
 
-export fn satya_validate_float_non_negative(value: f64) i32 {
+export fn dhi_validate_float_non_negative(value: f64) i32 {
     return if (validators_comp.validateNonNegative(f64, value)) 1 else 0;
 }
 
-export fn satya_validate_float_non_positive(value: f64) i32 {
+export fn dhi_validate_float_non_positive(value: f64) i32 {
     return if (validators_comp.validateNonPositive(f64, value)) 1 else 0;
 }
 
-export fn satya_validate_float_finite(value: f64) i32 {
+export fn dhi_validate_float_finite(value: f64) i32 {
     return if (validators_comp.validateFinite(value)) 1 else 0;
 }
 
 // IPv6 validation
-export fn satya_validate_ipv6(str: [*:0]const u8) i32 {
+export fn dhi_validate_ipv6(str: [*:0]const u8) i32 {
     const ip = std.mem.span(str);
     return if (validateIpv6(ip)) @as(i32, 1) else @as(i32, 0);
 }
@@ -284,7 +284,7 @@ fn validateIpv6(ip: []const u8) bool {
 /// High-performance batch user validation (optimized fast path)
 /// Validates arrays of names, emails, and ages in a single call
 /// Returns number of valid users
-export fn satya_validate_users_batch_optimized(
+export fn dhi_validate_users_batch_optimized(
     names: [*]const [*:0]const u8,
     emails: [*]const [*:0]const u8,
     ages: [*]const i64,
@@ -306,7 +306,7 @@ export fn satya_validate_users_batch_optimized(
 }
 
 /// Batch integer validation with SIMD optimization
-export fn satya_validate_int_batch_simd(
+export fn dhi_validate_int_batch_simd(
     values: [*]const i64,
     count: usize,
     min: i64,
@@ -319,7 +319,7 @@ export fn satya_validate_int_batch_simd(
 }
 
 /// Batch string length validation
-export fn satya_validate_string_length_batch(
+export fn dhi_validate_string_length_batch(
     strings: [*]const [*:0]const u8,
     count: usize,
     min_len: usize,
@@ -332,7 +332,7 @@ export fn satya_validate_string_length_batch(
 }
 
 /// Batch email validation
-export fn satya_validate_email_batch(
+export fn dhi_validate_email_batch(
     emails: [*]const [*:0]const u8,
     count: usize,
     results: [*]u8,
@@ -378,18 +378,18 @@ pub const CParsedValue = extern struct {
 };
 
 /// FNV-1a hash for field names (exported for Python to pre-compute hashes)
-export fn satya_hash_field_name(name: [*]const u8, len: usize) u64 {
+export fn dhi_hash_field_name(name: [*]const u8, len: usize) u64 {
     return simd_json.hashFieldName(name[0..len]);
 }
 
 /// Skip whitespace in JSON using SIMD
-export fn satya_skip_whitespace(json: [*]const u8, len: usize, start: usize) usize {
+export fn dhi_skip_whitespace(json: [*]const u8, len: usize, start: usize) usize {
     return simd_json.skipWhitespaceSIMD(json[0..len], start);
 }
 
 /// Parse a single JSON value
 /// Returns the value type and populates the output struct
-export fn satya_parse_json_value(
+export fn dhi_parse_json_value(
     json: [*]const u8,
     len: usize,
     start: usize,
@@ -440,7 +440,7 @@ export fn satya_parse_json_value(
 
 /// Extract a JSON string (starting after opening quote)
 /// Returns the string slice and end position
-export fn satya_extract_json_string(
+export fn dhi_extract_json_string(
     json: [*]const u8,
     len: usize,
     start: usize,
@@ -462,7 +462,7 @@ export fn satya_extract_json_string(
 }
 
 /// Parse a JSON integer
-export fn satya_parse_json_int(
+export fn dhi_parse_json_int(
     json: [*]const u8,
     len: usize,
     start: usize,
@@ -483,7 +483,7 @@ export fn satya_parse_json_int(
 }
 
 /// Parse a JSON float
-export fn satya_parse_json_float(
+export fn dhi_parse_json_float(
     json: [*]const u8,
     len: usize,
     start: usize,
@@ -501,7 +501,7 @@ export fn satya_parse_json_float(
 }
 
 /// Skip a JSON value (for unknown fields)
-export fn satya_skip_json_value(
+export fn dhi_skip_json_value(
     json: [*]const u8,
     len: usize,
     start: usize,

--- a/typescript-runtime-type-benchmarks/README.md
+++ b/typescript-runtime-type-benchmarks/README.md
@@ -13,9 +13,9 @@ cd typescript-runtime-type-benchmarks
 bun install
 
 # Copy dhi files
-cp /path/to/satya-zig/js-bindings/dhi.wasm cases/
-cp /path/to/satya-zig/js-bindings/schema.ts cases/dhi-schema.ts
-cp /path/to/satya-zig/typescript-runtime-type-benchmarks/dhi.ts cases/
+cp /path/to/dhi/js-bindings/dhi.wasm cases/
+cp /path/to/dhi/js-bindings/schema.ts cases/dhi-schema.ts
+cp /path/to/dhi/typescript-runtime-type-benchmarks/dhi.ts cases/
 
 # Run dhi benchmark
 bun index.ts run dhi


### PR DESCRIPTION
## Summary

Complete rename of `satya` → `dhi` across the entire codebase.

### C ABI & Build
- `src/c_api.zig`: 47 exported functions `satya_*` → `dhi_*`
- `build.zig`: library names `satya` → `dhi`
- `_native.c`, `validator.py`, `setup.py`: Python bindings
- `build-wheels.yml`: CI artifact paths

### Docs & Examples
- DOCS.md, CLAUDE.md, ADR.md, JS docs, Zig examples
- Fixed stale 28M → 24M claims

### Regression Tests
- 8 tests: performance baselines (>5M users/sec) + correctness
- **202 Python tests pass, Zig tests pass**