### PR TITLE
[codex] Speed up JSON validation parsing

### DIFF
--- a/benchmarks/json_batch_hot_paths.zig
+++ b/benchmarks/json_batch_hot_paths.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const json_batch = @import("json_batch_validator");
+
+const ITERATIONS = 50_000;
+const ITEMS_PER_BATCH = 16;
+
+const Timer = struct {
+    start_ns: u64,
+
+    fn nowNs() u64 {
+        var ts: std.c.timespec = undefined;
+        _ = std.c.clock_gettime(.MONOTONIC, &ts);
+        return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    }
+
+    fn start() Timer {
+        return .{ .start_ns = nowNs() };
+    }
+
+    fn read(self: Timer) u64 {
+        return nowNs() - self.start_ns;
+    }
+};
+
+pub fn main() !void {
+    const allocator = std.heap.smp_allocator;
+
+    const json =
+        \\[
+        \\  {"name": "Alice", "age": 25, "email": "alice@example.com"},
+        \\  {"name": "Bob", "age": 30, "email": "bob@example.com"},
+        \\  {"name": "Carol", "age": 28, "email": "carol@example.com"},
+        \\  {"name": "Dave", "age": 31, "email": "dave@example.com"},
+        \\  {"name": "Erin", "age": 26, "email": "erin@example.com"},
+        \\  {"name": "Faye", "age": 29, "email": "faye@example.com"},
+        \\  {"name": "Gus", "age": 41, "email": "gus@example.com"},
+        \\  {"name": "Hana", "age": 33, "email": "hana@example.com"},
+        \\  {"name": "Ira", "age": 22, "email": "ira@example.com"},
+        \\  {"name": "Jules", "age": 36, "email": "jules@example.com"},
+        \\  {"name": "Kai", "age": 27, "email": "kai@example.com"},
+        \\  {"name": "Lena", "age": 24, "email": "lena@example.com"},
+        \\  {"name": "Mika", "age": 39, "email": "mika@example.com"},
+        \\  {"name": "Noor", "age": 35, "email": "noor@example.com"},
+        \\  {"name": "Omar", "age": 32, "email": "omar@example.com"},
+        \\  {"name": "Pia", "age": 23, "email": "pia@example.com"}
+        \\]
+    ;
+
+    const specs = [_]json_batch.FieldSpec{
+        .{ .name = "name", .validator_type = .String, .param1 = 2, .param2 = 100 },
+        .{ .name = "age", .validator_type = .Int, .param1 = 18, .param2 = 120 },
+        .{ .name = "email", .validator_type = .Email },
+    };
+
+    var valid_count: usize = 0;
+    const timer = Timer.start();
+    for (0..ITERATIONS) |_| {
+        const results = try json_batch.validateJsonArray(json, &specs, allocator);
+        for (results) |result| {
+            valid_count +%= @intFromBool(result.is_valid);
+        }
+        allocator.free(results);
+    }
+    std.mem.doNotOptimizeAway(valid_count);
+
+    const elapsed_ns = timer.read();
+    const total_items = ITERATIONS * ITEMS_PER_BATCH;
+    const ns_per_item = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(total_items));
+    const items_per_sec = @as(f64, @floatFromInt(total_items)) / (@as(f64, @floatFromInt(elapsed_ns)) / std.time.ns_per_s);
+    std.debug.print("json_batch_array: {d:.2} ns/item, {d:.0} items/sec, valid={d}\n", .{
+        ns_per_item,
+        items_per_sec,
+        valid_count,
+    });
+}

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/json_validator.zig"),
     });
     json_validator_mod.addImport("validator", validator_mod);
+    const json_batch_validator_mod = b.addModule("json_batch_validator", .{
+        .root_source_file = b.path("src/json_batch_validator.zig"),
+    });
 
     // Create SIMD JSON parser module
     const simd_json_mod = b.addModule("simd_json_parser", .{
@@ -236,6 +239,17 @@ pub fn build(b: *std.Build) void {
 
     const run_simd_json_tests = b.addRunArtifact(simd_json_tests);
 
+    // Tests for JSON batch validator module
+    const json_batch_validator_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/json_batch_validator.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const run_json_batch_validator_tests = b.addRunArtifact(json_batch_validator_tests);
+
     // Test step runs all tests
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_validator_tests.step);
@@ -243,6 +257,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_json_validator_tests.step);
     test_step.dependOn(&run_model_tests.step);
     test_step.dependOn(&run_simd_json_tests.step);
+    test_step.dependOn(&run_json_batch_validator_tests.step);
 
     // Benchmark executable
     const benchmark = b.addExecutable(.{
@@ -260,4 +275,18 @@ pub fn build(b: *std.Build) void {
     const run_benchmark = b.addRunArtifact(benchmark);
     const bench_step = b.step("bench", "Run performance benchmarks");
     bench_step.dependOn(&run_benchmark.step);
+
+    const json_batch_benchmark = b.addExecutable(.{
+        .name = "json_batch_hot_paths",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("benchmarks/json_batch_hot_paths.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+        }),
+    });
+    json_batch_benchmark.root_module.addImport("json_batch_validator", json_batch_validator_mod);
+
+    const run_json_batch_benchmark = b.addRunArtifact(json_batch_benchmark);
+    const bench_json_batch_step = b.step("bench-json-batch", "Run JSON batch validator benchmarks");
+    bench_json_batch_step.dependOn(&run_json_batch_benchmark.step);
 }

--- a/src/json_batch_validator.zig
+++ b/src/json_batch_validator.zig
@@ -50,24 +50,25 @@ pub fn validateJsonArray(
 ) ![]ValidationResult {
     var results: std.ArrayList(ValidationResult) = .empty;
     defer results.deinit(allocator);
-    
+
     // Parse JSON
-    const parsed = try std.json.parseFromSlice(
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(
         std.json.Value,
-        allocator,
+        arena.allocator(),
         json_bytes,
         .{},
     );
-    defer parsed.deinit();
-    
-    const array = parsed.value.array;
-    
+
+    const array = parsed.array;
+
     // Validate each item
     for (array.items) |item| {
         const result = validateJsonObject(item.object, field_specs);
         try results.append(allocator, result);
     }
-    
+
     return try results.toOwnedSlice(allocator);
 }
 
@@ -80,7 +81,7 @@ fn validateJsonObject(
         const field_value = obj.get(spec.name) orelse {
             return .{ .is_valid = false, .error_field = spec.name };
         };
-        
+
         const is_valid = switch (spec.validator_type) {
             .Int => validateIntField(field_value, spec.param1, spec.param2),
             .IntGt => blk: {
@@ -155,12 +156,12 @@ fn validateJsonObject(
             },
             .Boolean => field_value == .bool,
         };
-        
+
         if (!is_valid) {
             return .{ .is_valid = false, .error_field = spec.name };
         }
     }
-    
+
     return .{ .is_valid = true };
 }
 
@@ -178,7 +179,7 @@ fn validateStringField(value: std.json.Value, min_len: i64, max_len: i64) bool {
 
 test "JSON array validation" {
     const allocator = std.testing.allocator;
-    
+
     const json =
         \\[
         \\  {"name": "Alice", "age": 25, "email": "alice@example.com"},
@@ -186,16 +187,16 @@ test "JSON array validation" {
         \\  {"name": "X", "age": 15, "email": "invalid"}
         \\]
     ;
-    
+
     const specs = [_]FieldSpec{
         .{ .name = "name", .validator_type = .String, .param1 = 2, .param2 = 100 },
         .{ .name = "age", .validator_type = .Int, .param1 = 18, .param2 = 120 },
         .{ .name = "email", .validator_type = .Email },
     };
-    
+
     const results = try validateJsonArray(json, &specs, allocator);
     defer allocator.free(results);
-    
+
     try std.testing.expect(results[0].is_valid);
     try std.testing.expect(results[1].is_valid);
     try std.testing.expect(!results[2].is_valid); // Multiple failures

--- a/src/json_validator.zig
+++ b/src/json_validator.zig
@@ -8,11 +8,12 @@ const validator = @import("validator");
 ///   const user = try parseAndValidate(User, json_string, allocator);
 pub fn parseAndValidate(comptime T: type, json_str: []const u8, allocator: std.mem.Allocator) !T {
     // Parse JSON to intermediate representation
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
-    defer parsed.deinit();
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), json_str, .{});
 
     // Convert to target type with validation
-    return try fromJsonValue(T, parsed.value, allocator);
+    return try fromJsonValue(T, parsed, allocator);
 }
 
 /// Convert a JSON Value to a typed struct with validation
@@ -48,7 +49,7 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
 
                 // Handle missing fields
                 if (json_value == null) {
-                    if (@typeInfo(field.type) == .@"optional") {
+                    if (@typeInfo(field.type) == .optional) {
                         @field(result, field.name) = null;
                     } else {
                         try errors.add(field.name, "Required field missing");
@@ -68,17 +69,17 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
                         try errors.add(field.name, msg);
                         // Set default values based on type
                         @field(result, field.name) = switch (@typeInfo(field.type)) {
-                            .@"bool" => false,
-                            .@"int" => 0,
-                            .@"float" => 0.0,
-                            .@"pointer" => |ptr_info| blk: {
+                            .bool => false,
+                            .int => 0,
+                            .float => 0.0,
+                            .pointer => |ptr_info| blk: {
                                 if (ptr_info.size == .slice and ptr_info.child == u8) {
                                     break :blk "";
                                 } else {
                                     return error.UnsupportedType;
                                 }
                             },
-                            .@"optional" => null,
+                            .optional => null,
                             else => return error.UnsupportedType,
                         };
                     }
@@ -107,8 +108,8 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
 /// Check if a type is []const u8 (an allocated string slice)
 fn isStringSliceType(comptime T: type) bool {
     const info = @typeInfo(T);
-    if (info == .@"pointer") {
-        const ptr = info.@"pointer";
+    if (info == .pointer) {
+        const ptr = info.pointer;
         return ptr.size == .slice and ptr.child == u8;
     }
     return false;
@@ -119,10 +120,10 @@ fn fromJsonValueTyped(comptime T: type, value: std.json.Value, allocator: std.me
     const type_info = @typeInfo(T);
 
     return switch (type_info) {
-        .@"bool" => if (value == .bool) value.bool else error.TypeMismatch,
-        .@"int" => if (value == .integer) std.math.cast(T, value.integer) orelse error.IntegerOverflow else error.TypeMismatch,
-        .@"float" => if (value == .float) @as(T, @floatCast(value.float)) else if (value == .integer) @as(T, @floatFromInt(value.integer)) else error.TypeMismatch,
-        .@"pointer" => |ptr_info| {
+        .bool => if (value == .bool) value.bool else error.TypeMismatch,
+        .int => if (value == .integer) std.math.cast(T, value.integer) orelse error.IntegerOverflow else error.TypeMismatch,
+        .float => if (value == .float) @as(T, @floatCast(value.float)) else if (value == .integer) @as(T, @floatFromInt(value.integer)) else error.TypeMismatch,
+        .pointer => |ptr_info| {
             if (ptr_info.size == .slice and ptr_info.child == u8) {
                 if (value == .string) {
                     return try allocator.dupe(u8, value.string);
@@ -131,7 +132,7 @@ fn fromJsonValueTyped(comptime T: type, value: std.json.Value, allocator: std.me
             }
             return error.UnsupportedType;
         },
-        .@"optional" => |opt_info| {
+        .optional => |opt_info| {
             if (value == .null) return null;
             return try fromJsonValueTyped(opt_info.child, value, allocator);
         },
@@ -142,12 +143,13 @@ fn fromJsonValueTyped(comptime T: type, value: std.json.Value, allocator: std.me
 /// BatchValidate validates multiple JSON objects from an array.
 /// Validates multiple JSON objects from an array.
 pub fn batchValidate(comptime T: type, json_array: []const u8, allocator: std.mem.Allocator) ![]validator.ValidationResult(T) {
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_array, .{});
-    defer parsed.deinit();
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), json_array, .{});
 
-    if (parsed.value != .array) return error.ExpectedArray;
+    if (parsed != .array) return error.ExpectedArray;
 
-    const items = parsed.value.array.items;
+    const items = parsed.array.items;
     var results = try allocator.alloc(validator.ValidationResult(T), items.len);
 
     for (items, 0..) |item, i| {
@@ -224,7 +226,7 @@ test "parseAndValidate - missing required field" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name": "Bob"}
     ;
 
@@ -238,7 +240,7 @@ test "parseAndValidate - type mismatch" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name": "Carol", "age": "not a number"}
     ;
 
@@ -253,7 +255,7 @@ test "parseAndValidate - with validation conventions" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name_ne": "", "email": "invalid", "age": 27}
     ;
 


### PR DESCRIPTION
## Summary

- Use a stack-owned arena with `std.json.parseFromSliceLeaky` in JSON validation paths to avoid the heap-allocated `Parsed` arena wrapper per parse.
- Apply the same parsing path to `json_batch_validator` while preserving the returned results allocation contract.
- Add `json_batch_validator` to the test step and add `zig build bench-json-batch` for the C/API-style JSON batch hot path.

## Benchmark notes

Compared against `origin/main` with the same local benchmark harness:

- `zig build bench`: JSON parse + validate improved from ~9,942 ns/parse to ~5,143 ns/parse.
- `zig build bench`: batch validation improved from ~5,356 ns/item to ~2,995 ns/item.
- `zig build bench-json-batch`: JSON batch benchmark improved from ~346 ns/item to ~304 ns/item.

## Validation

- `zig build test bench bench-json-batch --summary all` (68/68 tests passed)
- `zig build --summary all`
- `git diff --check`
