### PR TITLE
fix: drop yuku-parser from runtime deps (v1.3.5) — zero-dep package

### DIFF
--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -99,6 +99,7 @@
     "ai": "^6.0.71",
     "arktype": "^2.1.29",
     "typescript": "^5.9.3",
+    "yuku-parser": "^0.4.4",
     "zod": "^4.3.6",
     "zod-to-json-schema": "^3.25.1"
   },
@@ -112,8 +113,5 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "dependencies": {
-    "yuku-parser": "^0.4.4"
   }
 }

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.3.4"
+version = "1.3.5"
 description = "Ultra-fast data validation for Python - 33M+ rows/sec, powered by Zig"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Problem

`npm install dhi@1.3.4` pulls in **yuku-parser + 11 platform-specific native binding packages** because it was listed under `dependencies` — despite dhi shipping as a zero-dependency 28KB WASM module.

## Fix

- Move `yuku-parser` to `devDependencies`. It's only used by the in-repo `ts-to-dhi.ts` codegen script + `test-yuku.ts` scratch — neither is in the build (`tsconfig.build.json` includes only `schema*.ts`/`index.ts`) nor the published `files` glob.
- **npm `dependencies` block is now gone entirely → zero runtime deps.**
- Python (`pyproject.toml`) already has zero runtime deps. Confirmed.
- Lockstep bump Python + TS to **1.3.5**.

Tagging `v1.3.5` after merge republishes both with the clean dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)