### PR TITLE
fix(ci): wheel test gate imports installed wheel, not source (v1.3.6)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,15 +25,6 @@ jobs:
             arch: arm64
             target: aarch64-macos-none
             artifact: zig-lib-macos-arm64
-          # x86_64 macOS dylib is CROSS-COMPILED on the arm64 runner (Zig targets
-          # any OS/arch from any host). This deliberately avoids the deprecated,
-          # scarce macos-13 Intel runner gating the whole Zig matrix — which in
-          # turn gates every build_wheels job. Verified locally: arm64 host +
-          # -Dtarget=x86_64-macos-none -> valid x86_64 Mach-O dylib.
-          - os: macos-latest
-            arch: x86_64
-            target: x86_64-macos-none
-            artifact: zig-lib-macos-x86_64
 
     steps:
       - uses: actions/checkout@v5
@@ -84,10 +75,6 @@ jobs:
             arch: arm64
             zig-artifact: zig-lib-macos-arm64
             cibw-archs: arm64
-          - os: macos-13
-            arch: x86_64
-            zig-artifact: zig-lib-macos-x86_64
-            cibw-archs: x86_64
 
     steps:
       - uses: actions/checkout@v5
@@ -128,15 +115,18 @@ jobs:
           CIBW_ENABLE: cpython-freethreading
           CIBW_BEFORE_BUILD: |
             pip install "setuptools>=77.0.0" wheel "packaging>=24.2"
-          # Test gate: install each built wheel and run the full test suite against
-          # it, per Python version, BEFORE anything is published — this is what
-          # stops a broken wheel from ever reaching PyPI.
-          # NOTE: use {package} (the package-dir, ./python-bindings), NOT {project}
-          # (the repo root) — the tests live in python-bindings/tests, so {project}/tests
-          # resolves to a nonexistent dir and pytest exits 4 (no tests collected),
-          # failing every build.
+          # Test gate: install each built wheel and run the test suite against it,
+          # per Python version, BEFORE anything is published — this is what stops a
+          # broken wheel from ever reaching PyPI.
+          # CRITICAL: use CIBW_TEST_SOURCES so cibuildwheel COPIES tests/ into an
+          # isolated test dir and runs from there. Pointing pytest at {package}/tests
+          # inside the project tree instead puts the repo on sys.path, so `import dhi`
+          # resolves to the uncompiled SOURCE package (no _dhi_native.so) and shadows
+          # the installed wheel — _dhi_native is None and every native test crashes.
+          # Copying tests out means the only importable `dhi` is the wheel under test.
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: python -m pytest {package}/tests -q
+          CIBW_TEST_SOURCES: tests
+          CIBW_TEST_COMMAND: python -m pytest tests -q
           # Skip the test run only on emulated aarch64 wheels (pytest under QEMU is
           # extremely slow); the wheels are still built and shipped.
           CIBW_TEST_SKIP: "*-manylinux_aarch64 *-musllinux_aarch64"

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.3.5"
+version = "1.3.6"
 description = "Ultra-fast data validation for Python - 33M+ rows/sec, powered by Zig"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Problem

1.3.4 and 1.3.5 never reached **PyPI** — the wheel build's test gate failed on macOS with:
```
AttributeError: 'NoneType' object has no attribute 'validate_batch_direct'
```

## Root cause (reproduced locally)

`CIBW_TEST_COMMAND: python -m pytest {package}/tests` ran from inside the project, so cwd landed on `sys.path` and `import dhi` resolved to the **source** `python-bindings/dhi/` instead of the installed wheel. A clean checkout's source `dhi/` has no compiled `_dhi_native.so` → imports as `None` → `test_regression_benchmarks.py` (calls native unguarded) crashes.

- From a neutral cwd: installed wheel imports, native loads, suite passes ✅
- From the project dir: source shadows the wheel, `_dhi_native is None`, fails ❌

The **published wheels were always fine** — `libdhi.dylib` is bundled and linked via `@loader_path`. Only the gate was misconfigured (newly triggered by the recent `{package}/tests` change).

## Fix

- `CIBW_TEST_SOURCES: tests` → cibuildwheel copies `tests/` into an isolated dir and runs from there, so the only importable `dhi` is the wheel under test.
- Drop the deprecated `macos-13` Intel runner (queued forever, wedged the run) + its orphan `zig-lib-macos-x86_64` artifact. Drops x86_64 macOS wheels (Intel Macs fall back to sdist).
- Lockstep bump to **1.3.6**.

Tagging `v1.3.6` after merge publishes both registries cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)