### PR TITLE
fix: native SIGBUS on Py≤3.10 + wheel test-sources path (v1.3.7)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -118,15 +118,17 @@ jobs:
           # Test gate: install each built wheel and run the test suite against it,
           # per Python version, BEFORE anything is published — this is what stops a
           # broken wheel from ever reaching PyPI.
-          # CRITICAL: use CIBW_TEST_SOURCES so cibuildwheel COPIES tests/ into an
-          # isolated test dir and runs from there. Pointing pytest at {package}/tests
-          # inside the project tree instead puts the repo on sys.path, so `import dhi`
+          # CRITICAL: use CIBW_TEST_SOURCES so cibuildwheel COPIES the tests into a
+          # temp dir OUTSIDE the source tree and runs from there. Pointing pytest at
+          # the in-tree tests instead puts the repo on sys.path, so `import dhi`
           # resolves to the uncompiled SOURCE package (no _dhi_native.so) and shadows
           # the installed wheel — _dhi_native is None and every native test crashes.
-          # Copying tests out means the only importable `dhi` is the wheel under test.
+          # NOTE: test-sources paths are relative to the REPO ROOT (cibuildwheel's
+          # working dir), NOT the package-dir — hence python-bindings/tests, and the
+          # test command references that same copied relative path.
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_SOURCES: tests
-          CIBW_TEST_COMMAND: python -m pytest tests -q
+          CIBW_TEST_SOURCES: python-bindings/tests
+          CIBW_TEST_COMMAND: python -m pytest python-bindings/tests -q
           # Skip the test run only on emulated aarch64 wheels (pytest under QEMU is
           # extremely slow); the wheels are still built and shipped.
           CIBW_TEST_SKIP: "*-manylinux_aarch64 *-musllinux_aarch64"

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/dhi/_native.c
+++ b/python-bindings/dhi/_native.c
@@ -2499,9 +2499,17 @@ static PyObject* py_dump_json_compiled(PyObject* self_unused, PyObject* args) {
 // Stores field values in a C array instead of Python __dict__.
 // This eliminates PyDict overhead and provides ~6x speedup over BaseModel.
 
-// Instance object - stores field values directly in C array
+// Instance object - stores field values directly in C array.
+// MUST use PyObject_VAR_HEAD (not PyObject_HEAD): the type sets tp_itemsize, so
+// CPython treats instances as variable-sized and writes the item count into
+// ob_size at tp_alloc time. With a plain PyObject_HEAD, ob_size would alias
+// values[0], and populating field 0 would clobber it — corrupting Py_SIZE().
+// On CPython <=3.10 a heap subclass stores __dict__ at a negative offset computed
+// from Py_SIZE(obj), so a corrupted ob_size yields a wild __dict__ pointer and a
+// SIGBUS in GC at interpreter shutdown. VAR_HEAD gives ob_size its own slot ahead
+// of values[], so it stays = n_fields and the dict-offset math is correct.
 typedef struct {
-    PyObject_HEAD
+    PyObject_VAR_HEAD
     PyObject *values[];  // Flexible array member - holds field values
 } DhiStructObject;
 

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.3.6"
+version = "1.3.7"
 description = "Ultra-fast data validation for Python - 33M+ rows/sec, powered by Zig"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Two fixes that finally unblock PyPI, validated end-to-end via a workflow_dispatch run (all wheel jobs green, from_json exercised inside the cp39/cp310 wheels).

## 1. Native memory-safety bug (the real blocker)

`Struct.from_json` bus-errored at interpreter shutdown on **Python 3.9 and 3.10** (latent in the shipped 1.3.3 — never caught because the wheel test gate didn't actually run against the installed wheel until now).

- **Cause:** `DhiStructObject` set `tp_itemsize` but used `PyObject_HEAD`, so `ob_size` aliased `values[0]`. Populating field 0 corrupted `ob_size`; on CPython ≤3.10 a heap subclass's `__dict__` sits at a `Py_SIZE`-derived negative offset → wild pointer → SIGBUS in GC at shutdown. 3.11+ managed dicts don't read `ob_size` that way (the version split).
- **Fix:** `PyObject_VAR_HEAD` — `ob_size` gets its own header slot, stays `= n_fields`.
- **Verified locally:** cp39 233 passed (was bus error), 3.10/3.12/3.14t green, no regression.

## 2. Wheel test-sources path

`CIBW_TEST_SOURCES` paths are relative to the repo root, not the package-dir — `tests` → `python-bindings/tests`.

## Result
PyPI publish should finally succeed for all of cp39–cp314t. Lockstep bump to **1.3.7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)