### PR TITLE
fix: migrate reflection and array syntax for Zig 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Zig 0.16.0
-        shell: bash
-        run: |
-          case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)    ZIG_DIR="zig-x86_64-linux-0.16.0" ;;
-            Linux-ARM64)  ZIG_DIR="zig-aarch64-linux-0.16.0" ;;
-            macOS-ARM64)  ZIG_DIR="zig-aarch64-macos-0.16.0" ;;
-            macOS-X64)    ZIG_DIR="zig-x86_64-macos-0.16.0" ;;
-            *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
-          esac
-          curl -fsSL "https://ziglang.org/download/0.16.0/${ZIG_DIR}.tar.xz" -o zig.tar.xz
-          tar -xf zig.tar.xz
-          echo "${PWD}/${ZIG_DIR}" >> "$GITHUB_PATH"
+      - name: Setup Zig 0.17-dev
+        uses: mlugg/setup-zig@v2
+        with:
+          version: master
 
       - name: Build (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast
@@ -48,12 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Zig 0.16.0
-        shell: bash
-        run: |
-          curl -fsSL https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz -o zig.tar.xz
-          tar -xf zig.tar.xz
-          echo "${PWD}/zig-x86_64-linux-0.16.0" >> "$GITHUB_PATH"
+      - name: Setup Zig 0.17-dev
+        uses: mlugg/setup-zig@v2
+        with:
+          version: master
 
       - name: Build Zig library
         run: zig build -Doptimize=ReleaseFast

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .dhi,
     .fingerprint = 0x29d582bd9fdb3d17,
     .version = "0.1.0",
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.17.0-dev.1",
 
     .dependencies = .{},
 

--- a/src/envoy_wasm_filter.zig
+++ b/src/envoy_wasm_filter.zig
@@ -122,7 +122,7 @@ const RequestState = struct {
 var config_storage: [MAX_CONFIG_BYTES]u8 = undefined;
 var route_rules: [MAX_ROUTES]RouteRule = undefined;
 var field_rules: [MAX_RULES]FieldRule = undefined;
-var request_states: [MAX_STREAMS]RequestState = [_]RequestState{.{}} ** MAX_STREAMS;
+var request_states: [MAX_STREAMS]RequestState = @splat(.{});
 var host_alloc_storage: [MAX_HOST_ALLOC_BYTES]u8 align(8) = undefined;
 var host_alloc_offset: usize = 0;
 var config: FilterConfig = .{ .routes = &.{} };

--- a/src/json_validator.zig
+++ b/src/json_validator.zig
@@ -28,13 +28,13 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
             defer errors.deinit();
 
             // Track which string fields were allocated so we can free on error
-            var string_allocated: [struct_info.fields.len]bool = .{false} ** struct_info.fields.len;
+            var string_allocated: [struct_info.field_names.len]bool = @splat(false);
 
             errdefer {
-                inline for (struct_info.fields, 0..) |field, i| {
-                    if (comptime isStringSliceType(field.type)) {
+                inline for (struct_info.field_names, struct_info.field_types, 0..) |field_name, field_type, i| {
+                    if (comptime isStringSliceType(field_type)) {
                         if (string_allocated[i]) {
-                            allocator.free(@field(result, field.name));
+                            allocator.free(@field(result, field_name));
                         }
                     }
                 }
@@ -42,43 +42,44 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
 
             // Process fields manually to avoid comptime control flow issues
             comptime var field_index = 0;
-            inline while (field_index < struct_info.fields.len) : (field_index += 1) {
-                const field = struct_info.fields[field_index];
-                const json_value = value.object.get(field.name);
+            inline while (field_index < struct_info.field_names.len) : (field_index += 1) {
+                const field_name = struct_info.field_names[field_index];
+                const field_type = struct_info.field_types[field_index];
+                const json_value = value.object.get(field_name);
 
                 // Handle missing fields
                 if (json_value == null) {
-                    if (@typeInfo(field.type) == .@"optional") {
-                        @field(result, field.name) = null;
+                    if (@typeInfo(field_type) == .optional) {
+                        @field(result, field_name) = null;
                     } else {
-                        try errors.add(field.name, "Required field missing");
+                        try errors.add(field_name, "Required field missing");
                     }
                 } else {
                     // Handle present fields
                     const json_val = json_value.?;
-                    const field_result = fromJsonValueTyped(field.type, json_val, allocator);
+                    const field_result = fromJsonValueTyped(field_type, json_val, allocator);
                     if (field_result) |field_value| {
-                        @field(result, field.name) = field_value;
-                        if (comptime isStringSliceType(field.type)) {
+                        @field(result, field_name) = field_value;
+                        if (comptime isStringSliceType(field_type)) {
                             string_allocated[field_index] = true;
                         }
                     } else |err| {
                         const msg = try std.fmt.allocPrint(allocator, "Invalid value: {}", .{err});
                         defer allocator.free(msg);
-                        try errors.add(field.name, msg);
+                        try errors.add(field_name, msg);
                         // Set default values based on type
-                        @field(result, field.name) = switch (@typeInfo(field.type)) {
-                            .@"bool" => false,
-                            .@"int" => 0,
-                            .@"float" => 0.0,
-                            .@"pointer" => |ptr_info| blk: {
+                        @field(result, field_name) = switch (@typeInfo(field_type)) {
+                            .bool => false,
+                            .int => 0,
+                            .float => 0.0,
+                            .pointer => |ptr_info| blk: {
                                 if (ptr_info.size == .slice and ptr_info.child == u8) {
                                     break :blk "";
                                 } else {
                                     return error.UnsupportedType;
                                 }
                             },
-                            .@"optional" => null,
+                            .optional => null,
                             else => return error.UnsupportedType,
                         };
                     }
@@ -107,8 +108,8 @@ fn fromJsonValue(comptime T: type, value: std.json.Value, allocator: std.mem.All
 /// Check if a type is []const u8 (an allocated string slice)
 fn isStringSliceType(comptime T: type) bool {
     const info = @typeInfo(T);
-    if (info == .@"pointer") {
-        const ptr = info.@"pointer";
+    if (info == .pointer) {
+        const ptr = info.pointer;
         return ptr.size == .slice and ptr.child == u8;
     }
     return false;
@@ -119,10 +120,10 @@ fn fromJsonValueTyped(comptime T: type, value: std.json.Value, allocator: std.me
     const type_info = @typeInfo(T);
 
     return switch (type_info) {
-        .@"bool" => if (value == .bool) value.bool else error.TypeMismatch,
-        .@"int" => if (value == .integer) std.math.cast(T, value.integer) orelse error.IntegerOverflow else error.TypeMismatch,
-        .@"float" => if (value == .float) @as(T, @floatCast(value.float)) else if (value == .integer) @as(T, @floatFromInt(value.integer)) else error.TypeMismatch,
-        .@"pointer" => |ptr_info| {
+        .bool => if (value == .bool) value.bool else error.TypeMismatch,
+        .int => if (value == .integer) std.math.cast(T, value.integer) orelse error.IntegerOverflow else error.TypeMismatch,
+        .float => if (value == .float) @as(T, @floatCast(value.float)) else if (value == .integer) @as(T, @floatFromInt(value.integer)) else error.TypeMismatch,
+        .pointer => |ptr_info| {
             if (ptr_info.size == .slice and ptr_info.child == u8) {
                 if (value == .string) {
                     return try allocator.dupe(u8, value.string);
@@ -131,7 +132,7 @@ fn fromJsonValueTyped(comptime T: type, value: std.json.Value, allocator: std.me
             }
             return error.UnsupportedType;
         },
-        .@"optional" => |opt_info| {
+        .optional => |opt_info| {
             if (value == .null) return null;
             return try fromJsonValueTyped(opt_info.child, value, allocator);
         },
@@ -224,7 +225,7 @@ test "parseAndValidate - missing required field" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name": "Bob"}
     ;
 
@@ -238,7 +239,7 @@ test "parseAndValidate - type mismatch" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name": "Carol", "age": "not a number"}
     ;
 
@@ -253,7 +254,7 @@ test "parseAndValidate - with validation conventions" {
         age: u8,
     };
 
-    const json = 
+    const json =
         \\{"name_ne": "", "email": "invalid", "age": 27}
     ;
 

--- a/src/model.zig
+++ b/src/model.zig
@@ -236,35 +236,29 @@ pub const ValidationError = error{
 ///
 pub fn Model(comptime name: []const u8, comptime spec: anytype) type {
     const SpecType = @TypeOf(spec);
-    const spec_fields = @typeInfo(SpecType).@"struct".fields;
+    const spec_field_names = @typeInfo(SpecType).@"struct".field_names;
 
     return struct {
         /// The model name (for error messages and schemas)
         pub const Name = name;
 
         /// Number of fields in this model
-        pub const field_count = spec_fields.len;
+        pub const field_count = spec_field_names.len;
 
         /// Validate input data against the schema. Returns the validated data or an error.
         /// Equivalent to Pydantic's `model_validate()`.
         pub fn parse(input: anytype) ValidationError!@TypeOf(input) {
-            inline for (spec_fields) |sf| {
-                const desc: FieldDesc = @field(spec, sf.name);
-                const val = @field(input, sf.name);
-                try validateField(desc, val, sf.name);
+            inline for (spec_field_names) |field_name| {
+                const desc: FieldDesc = @field(spec, field_name);
+                const val = @field(input, field_name);
+                try validateField(desc, val, field_name);
             }
             return input;
         }
 
         /// Get field names as a comptime slice. Equivalent to `model_fields`.
         pub fn fieldNames() []const []const u8 {
-            comptime {
-                var names: [spec_fields.len][]const u8 = undefined;
-                for (spec_fields, 0..) |sf, i| {
-                    names[i] = sf.name;
-                }
-                return &names;
-            }
+            return spec_field_names;
         }
 
         /// Get the field descriptor for a named field.

--- a/src/simd_string.zig
+++ b/src/simd_string.zig
@@ -8,7 +8,6 @@ const std = @import("std");
 ///
 /// AVX-512 Support: Uses std.simd.suggestVectorLength() to dynamically
 /// select optimal SIMD width (32 for AVX2, 64 for AVX-512).
-
 /// Optimal SIMD block size - auto-detected at compile time.
 /// Uses 64 bytes on AVX-512 capable CPUs, 32 bytes otherwise.
 const optimal_block_size = std.simd.suggestVectorLength(u8) orelse 32;
@@ -16,7 +15,7 @@ const optimal_block_size = std.simd.suggestVectorLength(u8) orelse 32;
 /// Character frequency table for selecting rarest bytes in a needle.
 /// Lower values = rarer characters = fewer false positives in SIMD scan.
 const CHAR_FREQUENCY: [256]u8 = blk: {
-    var freq: [256]u8 = [_]u8{0} ** 256;
+    var freq: [256]u8 = @splat(0);
     // Space and common letters get high frequency
     freq[' '] = 255;
     freq['e'] = 250;

--- a/src/ultra_validator.zig
+++ b/src/ultra_validator.zig
@@ -3,16 +3,15 @@ const simd = @import("simd_validators.zig");
 
 /// 💥 ULTRA-VALIDATOR: Zero-allocation, maximum performance validation
 /// This eliminates all heap allocations for 50%+ performance gain
-
 /// 🚀 Error-free validation result (no allocations)
 pub const ValidationResult = packed struct {
     is_valid: bool,
     error_code: u8, // 0=valid, 1=too_short, 2=too_long, 3=invalid_format, etc.
-    
+
     pub inline fn valid() ValidationResult {
         return .{ .is_valid = true, .error_code = 0 };
     }
-    
+
     pub inline fn invalid(code: u8) ValidationResult {
         return .{ .is_valid = false, .error_code = code };
     }
@@ -30,7 +29,7 @@ pub const ErrorCode = struct {
 
 /// ⚡ Pre-computed lookup table for email characters (no branches!)
 const EMAIL_CHAR_VALID = blk: {
-    var table: [256]bool = [_]bool{false} ** 256;
+    var table: [256]bool = @splat(false);
     // a-z, A-Z, 0-9, @, ., -, _, +
     for ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@.-_+") |c| {
         table[c] = true;
@@ -42,17 +41,17 @@ const EMAIL_CHAR_VALID = blk: {
 pub inline fn validateEmailUltra(email: []const u8) ValidationResult {
     if (email.len < 5) return ValidationResult.invalid(ErrorCode.TOO_SHORT);
     if (email.len > 320) return ValidationResult.invalid(ErrorCode.TOO_LONG);
-    
+
     // Fast character validation using lookup table
     for (email) |c| {
         if (!EMAIL_CHAR_VALID[c]) return ValidationResult.invalid(ErrorCode.INVALID_FORMAT);
     }
-    
+
     // Use SIMD email validation
     if (!simd.validateEmailFast(email)) {
         return ValidationResult.invalid(ErrorCode.INVALID_EMAIL);
     }
-    
+
     return ValidationResult.valid();
 }
 
@@ -63,11 +62,8 @@ pub inline fn validateStringLengthUltra(str: []const u8, min: usize, max: usize)
     const too_short = @intFromBool(len < min);
     const too_long = @intFromBool(len > max);
     const error_code = too_short * ErrorCode.TOO_SHORT + too_long * ErrorCode.TOO_LONG;
-    
-    return ValidationResult{ 
-        .is_valid = error_code == 0, 
-        .error_code = @intCast(error_code) 
-    };
+
+    return ValidationResult{ .is_valid = error_code == 0, .error_code = @intCast(error_code) };
 }
 
 /// 🚀 Ultra-fast integer range validation (branch-free)
@@ -75,11 +71,8 @@ pub inline fn validateIntRangeUltra(value: i64, min: i64, max: i64) ValidationRe
     const too_low = @intFromBool(value < min);
     const too_high = @intFromBool(value > max);
     const error_code = too_low * ErrorCode.OUT_OF_RANGE + too_high * ErrorCode.OUT_OF_RANGE;
-    
-    return ValidationResult{ 
-        .is_valid = error_code == 0, 
-        .error_code = @intCast(error_code) 
-    };
+
+    return ValidationResult{ .is_valid = error_code == 0, .error_code = @intCast(error_code) };
 }
 
 /// 🌟 Cache-optimized user data layout (64-byte aligned)
@@ -88,15 +81,15 @@ pub const UserData = packed struct {
     name_len: u32,
     email_len: u32,
     // name and email data follow immediately after
-    
+
     pub fn getName(self: *const UserData) []const u8 {
         const data_ptr = @as([*]const u8, @ptrCast(self)) + @sizeOf(UserData);
         return data_ptr[0..self.name_len];
     }
-    
+
     pub fn getEmail(self: *const UserData) []const u8 {
         const data_ptr = @as([*]const u8, @ptrCast(self)) + @sizeOf(UserData);
-        return data_ptr[self.name_len..self.name_len + self.email_len];
+        return data_ptr[self.name_len .. self.name_len + self.email_len];
     }
 };
 
@@ -111,29 +104,29 @@ pub fn validateUserBatchUltraOptimized(
 ) usize {
     var valid_count: usize = 0;
     var i: usize = 0;
-    
+
     // SIMD processing - 4 users at once
     while (i + 4 <= users.len) : (i += 4) {
         // Extract ages into SIMD vector
-        const ages = @Vector(4, i64){ users[i].age, users[i+1].age, users[i+2].age, users[i+3].age };
+        const ages = @Vector(4, i64){ users[i].age, users[i + 1].age, users[i + 2].age, users[i + 3].age };
         const age_min_vec = @as(@Vector(4, i64), @splat(age_min));
         const age_max_vec = @as(@Vector(4, i64), @splat(age_max));
-        
+
         // SIMD age validation
         const ages_valid = ages >= age_min_vec and ages <= age_max_vec;
         const age_mask = @as(u8, @bitCast(ages_valid));
-        
+
         // Validate each user (unrolled for performance)
         inline for (0..4) |j| {
             const user = &users[i + j];
             const name = user.getName();
             const email = user.getEmail();
-            
+
             // Fast path validations
             const age_valid = ((age_mask >> @intCast(j)) & 1) == 1;
             const name_result = validateStringLengthUltra(name, name_min, name_max);
             const email_result = validateEmailUltra(email);
-            
+
             // Combine results (branchless)
             const all_valid = age_valid and name_result.is_valid and email_result.is_valid;
             const error_code = if (all_valid) ErrorCode.VALID else blk: {
@@ -141,36 +134,30 @@ pub fn validateUserBatchUltraOptimized(
                 if (!name_result.is_valid) break :blk name_result.error_code;
                 break :blk email_result.error_code;
             };
-            
-            results[i + j] = ValidationResult{ 
-                .is_valid = all_valid, 
-                .error_code = error_code 
-            };
+
+            results[i + j] = ValidationResult{ .is_valid = all_valid, .error_code = error_code };
             valid_count += @intFromBool(all_valid);
         }
     }
-    
+
     // Handle remaining users
     while (i < users.len) : (i += 1) {
         const user = &users[i];
         const age_result = validateIntRangeUltra(user.age, age_min, age_max);
         const name_result = validateStringLengthUltra(user.getName(), name_min, name_max);
         const email_result = validateEmailUltra(user.getEmail());
-        
+
         const all_valid = age_result.is_valid and name_result.is_valid and email_result.is_valid;
         const error_code = if (all_valid) ErrorCode.VALID else blk: {
             if (!age_result.is_valid) break :blk age_result.error_code;
             if (!name_result.is_valid) break :blk name_result.error_code;
             break :blk email_result.error_code;
         };
-        
-        results[i] = ValidationResult{ 
-            .is_valid = all_valid, 
-            .error_code = error_code 
-        };
+
+        results[i] = ValidationResult{ .is_valid = all_valid, .error_code = error_code };
         valid_count += @intFromBool(all_valid);
     }
-    
+
     return valid_count;
 }
 
@@ -185,7 +172,7 @@ pub fn validateUserBatchTurbo(
 ) usize {
     var valid_count: usize = 0;
     var i: usize = 0;
-    
+
     // Process 8 users at once (maximum vectorization)
     while (i + 8 <= users.len) : (i += 8) {
         // Extract ages for SIMD processing
@@ -193,39 +180,39 @@ pub fn validateUserBatchTurbo(
         inline for (0..8) |j| {
             ages[j] = users[i + j].age;
         }
-        
+
         const age_min_vec = @as(@Vector(8, i64), @splat(age_min));
         const age_max_vec = @as(@Vector(8, i64), @splat(age_max));
         const ages_valid = ages >= age_min_vec and ages <= age_max_vec;
         const age_mask = @as(u8, @bitCast(ages_valid));
-        
+
         // Process names and emails
         inline for (0..8) |j| {
             const user = &users[i + j];
             const name_len = user.name_len;
             const email_len = user.email_len;
-            
+
             const age_valid = ((age_mask >> @intCast(j)) & 1) == 1;
             const name_valid = name_len >= name_min and name_len <= name_max;
             const email_valid = email_len >= 5 and email_len <= 320; // Quick check
-            
+
             const is_valid = age_valid and name_valid and email_valid;
             results[i + j] = @intFromBool(is_valid);
             valid_count += @intFromBool(is_valid);
         }
     }
-    
+
     // Handle remaining users
     while (i < users.len) : (i += 1) {
         const user = &users[i];
         const age_valid = user.age >= age_min and user.age <= age_max;
         const name_valid = user.name_len >= name_min and user.name_len <= name_max;
         const email_valid = user.email_len >= 5 and user.email_len <= 320;
-        
+
         const is_valid = age_valid and name_valid and email_valid;
         results[i] = @intFromBool(is_valid);
         valid_count += @intFromBool(is_valid);
     }
-    
+
     return valid_count;
 }

--- a/src/validator.zig
+++ b/src/validator.zig
@@ -48,7 +48,6 @@ pub const ValidationError = struct {
         self: ValidationError,
         writer: anytype,
     ) !void {
-
         if (self.path.len > 0) {
             for (self.path, 0..) |segment, i| {
                 try writer.writeAll(segment);
@@ -71,7 +70,7 @@ pub const ValidationErrors = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) ValidationErrors {
-        return .{ 
+        return .{
             .errors = std.ArrayList(ValidationError).empty,
             .allocator = allocator,
         };
@@ -229,7 +228,7 @@ pub const Email = struct {
         }
         if (at_count != 1) return false;
         if (at_pos == 0 or at_pos == s.len - 1) return false;
-        
+
         // Check for at least one dot in domain
         const domain = s[at_pos + 1 ..];
         const has_dot = std.mem.indexOf(u8, domain, ".") != null;
@@ -316,20 +315,20 @@ pub fn validateStruct(comptime T: type, val: T, errors: *ValidationErrors) !void
     const info = @typeInfo(T);
     if (info != .@"struct") @compileError("validateStruct expects a struct");
 
-    inline for (info.@"struct".fields) |f| {
-        const field_val = @field(val, f.name);
+    inline for (info.@"struct".field_names) |field_name| {
+        const field_val = @field(val, field_name);
 
         // Convention: fields ending with "_ne" must be non-empty strings
-        if (std.mem.endsWith(u8, f.name, "_ne")) {
+        if (std.mem.endsWith(u8, field_name, "_ne")) {
             if (@TypeOf(field_val) == []const u8 and field_val.len == 0) {
-                try errors.add(f.name, "Field cannot be empty");
+                try errors.add(field_name, "Field cannot be empty");
             }
         }
 
         // Convention: fields named "email" or ending with "_email" must be valid emails
-        if (std.mem.eql(u8, f.name, "email") or std.mem.endsWith(u8, f.name, "_email")) {
+        if (std.mem.eql(u8, field_name, "email") or std.mem.endsWith(u8, field_name, "_email")) {
             if (@TypeOf(field_val) == []const u8) {
-                _ = Email.validate(field_val, errors, f.name) catch {};
+                _ = Email.validate(field_val, errors, field_name) catch {};
             }
         }
 


### PR DESCRIPTION
Closes #69.

## Summary
- migrate struct reflection from `fields` to Zig 0.17 `field_names`/`field_types`
- replace array repetition with `@splat`
- declare Zig 0.17-dev as the package minimum and run CI against Zig master

## Validation
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `zig build envoy -Doptimize=ReleaseFast`
- Python: 248 passed, 1 skipped
- TypeScript CI suites: 142 passed, 0 failed