### PR TITLE
chore: release v1.5.1

### DIFF
--- a/js-bindings/CHANGELOG.md
+++ b/js-bindings/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.1] - 2026-07-11
+
+### Fixed
+- Added Zig 0.17-dev compatibility for compile-time struct reflection.
+- Replaced deprecated array repetition syntax with `@splat`.
+- Updated CI and package metadata to require and test Zig 0.17-dev.
+
 ## [0.3.0] - 2025-01-04
 
 ### 🎉 Major Release - Drop-in Zod Replacement!

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.5.0"
+version = "1.5.1"
 description = "Ultra-fast data validation for Python - 33M+ rows/sec, powered by Zig"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Release v1.5.1

- publish Zig 0.17-dev compatibility from #70
- bump Python and npm packages in lockstep to 1.5.1
- document the compatibility changes

Closes #69.