### PR TITLE
ci: build v1.5.1 artifacts with Zig 0.17-dev

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,18 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup Zig 0.16.0
-        shell: bash
-        run: |
-          case "${{ runner.os }}-${{ runner.arch }}" in
-            Linux-X64)    ZIG_DIR="zig-x86_64-linux-0.16.0" ;;
-            macOS-ARM64)  ZIG_DIR="zig-aarch64-macos-0.16.0" ;;
-            macOS-X64)    ZIG_DIR="zig-x86_64-macos-0.16.0" ;;
-            *) echo "Unsupported runner: ${{ runner.os }}-${{ runner.arch }}"; exit 1 ;;
-          esac
-          curl -fsSL "https://ziglang.org/download/0.16.0/${ZIG_DIR}.tar.xz" -o zig.tar.xz
-          tar -xf zig.tar.xz
-          echo "${PWD}/${ZIG_DIR}" >> "$GITHUB_PATH"
+      - name: Setup Zig 0.17-dev
+        uses: mlugg/setup-zig@v2
+        with:
+          version: master
 
       - name: Build Zig library
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,12 +35,10 @@ jobs:
         working-directory: js-bindings
         run: bun install
 
-      - name: Setup Zig 0.16.0
-        shell: bash
-        run: |
-          curl -fsSL https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz -o zig.tar.xz
-          tar -xf zig.tar.xz
-          echo "${PWD}/zig-x86_64-linux-0.16.0" >> "$GITHUB_PATH"
+      - name: Setup Zig 0.17-dev
+        uses: mlugg/setup-zig@v2
+        with:
+          version: master
 
       - name: Build N-API native addon
         run: |


### PR DESCRIPTION
Updates the tag-triggered npm and PyPI workflows to use Zig 0.17-dev before tagging v1.5.1. This keeps release builds aligned with the compatibility migration in #70.