### PR TITLE
chore: release v1.5.2

### DIFF
--- a/js-bindings/CHANGELOG.md
+++ b/js-bindings/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.2] - 2026-07-11
+
+### Fixed
+- Unblocked npm publishing by removing the unsupported N-API build from the release workflow.
+- Aligned macOS wheel metadata with Zig 0.17's macOS 14.0 deployment target.
+- Enabled manual PyPI publishing from the wheel workflow.
+
 ## [1.5.1] - 2026-07-11
 
 ### Fixed

--- a/js-bindings/package.json
+++ b/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhi",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Ultra-fast Zod 4 drop-in replacement - 20x faster average, full API parity, SIMD WASM, 28KB binary",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/python-bindings/dhi/__init__.py
+++ b/python-bindings/dhi/__init__.py
@@ -17,7 +17,7 @@ Example:
     user = User(name="Alice", age=25, email="alice@example.com")
 """
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __author__ = "Rach Pradhan"
 
 # --- Core validators (original API) ---

--- a/python-bindings/pyproject.toml
+++ b/python-bindings/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dhi"
-version = "1.5.1"
+version = "1.5.2"
 description = "Ultra-fast data validation for Python - 33M+ rows/sec, powered by Zig"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- bump Python and TypeScript packages to 1.5.2
- document npm publishing and macOS wheel pipeline fixes
- keep ecosystem versions in lockstep

## Validation
- parsed Python project metadata and npm package metadata
- verified all package versions are synchronized at 1.5.2
- `git diff --check`